### PR TITLE
test: add unit test coverage for core packages (#6)

### DIFF
--- a/pkg/checks/custom_test.go
+++ b/pkg/checks/custom_test.go
@@ -1,0 +1,1236 @@
+package checks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func boolPtr(b bool) *bool { return &b }
+func intPtr(i int) *int    { return &i }
+
+// buildTestGraph creates a graph with several node types for use across tests.
+func buildTestGraph() *graph.Graph {
+	g := graph.New()
+
+	// ServiceAccount: default/my-sa (has cloud identity)
+	sa := graph.NewNode(graph.NodeServiceAccount, "default", "my-sa")
+	sa.Labels["app"] = "web"
+	sa.Labels["env"] = "prod"
+	sa.Metadata.CloudRoleARN = "arn:aws:iam::123456789012:role/my-role"
+	_ = g.AddNode(sa)
+
+	// ServiceAccount: kube-system/system-sa (no cloud identity, different namespace)
+	saSys := graph.NewNode(graph.NodeServiceAccount, "kube-system", "system-sa")
+	saSys.Labels["component"] = "controller"
+	_ = g.AddNode(saSys)
+
+	// Workload: default/web-deploy (privileged, hostNetwork)
+	wl := graph.NewNode(graph.NodeWorkload, "default", "web-deploy")
+	wl.Labels["app"] = "web"
+	wl.Metadata.PodSecurityContext = &graph.PodSecurityContext{
+		HostNetwork: true,
+		HostPID:     false,
+		HostIPC:     false,
+		HostPaths:   []string{"/var/run/docker.sock"},
+		Containers: []graph.ContainerSecurityInfo{
+			{
+				Name:                     "main",
+				Privileged:               true,
+				RunAsRoot:                true,
+				AllowPrivilegeEscalation: true,
+				Capabilities:             []string{"NET_ADMIN", "SYS_PTRACE"},
+				HasSecurityContext:       true,
+				ReadOnlyRootFilesystem:   true,
+			},
+		},
+	}
+	_ = g.AddNode(wl)
+
+	// Workload: default/safe-deploy (not privileged, no security context)
+	wlSafe := graph.NewNode(graph.NodeWorkload, "default", "safe-deploy")
+	wlSafe.Labels["app"] = "api"
+	_ = g.AddNode(wlSafe)
+
+	// Role: cluster-admin (cluster role)
+	role := graph.NewNode(graph.NodeRole, "", "cluster-admin")
+	role.Metadata.IsClusterRole = true
+	_ = g.AddNode(role)
+
+	// Role: default/my-role (namespace role)
+	nsRole := graph.NewNode(graph.NodeRole, "default", "my-role")
+	_ = g.AddNode(nsRole)
+
+	// CloudRole
+	cr := graph.NewNode(graph.NodeCloudRole, "", "my-cloud-role")
+	_ = g.AddNode(cr)
+
+	// Edge: sa -> role (binds)
+	bindEdge := graph.NewEdge(graph.EdgeBinds, sa.ID, role.ID)
+	_ = g.AddEdge(bindEdge)
+
+	return g
+}
+
+// writeTempYAML writes content to a temp YAML file and returns its path.
+func writeTempYAML(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "checks.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write temp YAML: %v", err)
+	}
+	return path
+}
+
+// ---------------------------------------------------------------------------
+// LoadCustomChecks
+// ---------------------------------------------------------------------------
+
+func TestLoadCustomChecks(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		file    bool // if false, use a non-existent path
+		wantErr bool
+		errMsg  string
+		nChecks int
+	}{
+		{
+			name: "valid config",
+			yaml: `checks:
+  - id: TEST001
+    name: Test check
+    severity: high
+    category: security
+    description: A test check
+    match:
+      kind: ServiceAccount
+    condition:
+      exists: true
+`,
+			file:    true,
+			nChecks: 1,
+		},
+		{
+			name: "multiple checks",
+			yaml: `checks:
+  - id: TEST001
+    name: First
+    match:
+      kind: Workload
+    condition:
+      exists: true
+  - id: TEST002
+    name: Second
+    match:
+      kind: Role
+    condition:
+      isClusterRole: true
+`,
+			file:    true,
+			nChecks: 2,
+		},
+		{
+			name:    "non-existent file",
+			file:    false,
+			wantErr: true,
+			errMsg:  "failed to read config file",
+		},
+		{
+			name:    "invalid yaml",
+			yaml:    `{{{{not yaml`,
+			file:    true,
+			wantErr: true,
+			errMsg:  "failed to parse config",
+		},
+		{
+			name: "missing id",
+			yaml: `checks:
+  - name: No ID
+    match:
+      kind: Workload
+    condition:
+      exists: true
+`,
+			file:    true,
+			wantErr: true,
+			errMsg:  "missing id",
+		},
+		{
+			name: "missing name",
+			yaml: `checks:
+  - id: TEST001
+    match:
+      kind: Workload
+    condition:
+      exists: true
+`,
+			file:    true,
+			wantErr: true,
+			errMsg:  "missing name",
+		},
+		{
+			name: "missing kind",
+			yaml: `checks:
+  - id: TEST001
+    name: No Kind
+    match: {}
+    condition:
+      exists: true
+`,
+			file:    true,
+			wantErr: true,
+			errMsg:  "missing match.kind",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var path string
+			if tt.file {
+				path = writeTempYAML(t, tt.yaml)
+			} else {
+				path = "/nonexistent/path/checks.yaml"
+			}
+
+			cfg, err := LoadCustomChecks(path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errMsg != "" {
+					if got := err.Error(); !contains(got, tt.errMsg) {
+						t.Errorf("error %q should contain %q", got, tt.errMsg)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(cfg.Checks) != tt.nChecks {
+				t.Errorf("got %d checks, want %d", len(cfg.Checks), tt.nChecks)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+func containsStr(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// kindToNodeType
+// ---------------------------------------------------------------------------
+
+func TestKindToNodeType(t *testing.T) {
+	tests := []struct {
+		kind string
+		want graph.NodeType
+	}{
+		{"workload", graph.NodeWorkload},
+		{"Workload", graph.NodeWorkload},
+		{"pod", graph.NodeWorkload},
+		{"deployment", graph.NodeWorkload},
+		{"statefulset", graph.NodeWorkload},
+		{"daemonset", graph.NodeWorkload},
+		{"job", graph.NodeWorkload},
+		{"cronjob", graph.NodeWorkload},
+		{"serviceaccount", graph.NodeServiceAccount},
+		{"ServiceAccount", graph.NodeServiceAccount},
+		{"sa", graph.NodeServiceAccount},
+		{"role", graph.NodeRole},
+		{"clusterrole", graph.NodeRole},
+		{"cloudrole", graph.NodeCloudRole},
+		{"scc", graph.NodeSCC},
+		{"networkpolicy", graph.NodeNetworkPolicy},
+		{"service", graph.NodeService},
+		{"unknown", graph.NodeWorkload}, // default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			got := kindToNodeType(tt.kind)
+			if got != tt.want {
+				t.Errorf("kindToNodeType(%q) = %q, want %q", tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// matchesNamespace
+// ---------------------------------------------------------------------------
+
+func TestMatchesNamespace(t *testing.T) {
+	node := &graph.Node{Namespace: "kube-system"}
+
+	tests := []struct {
+		name  string
+		match MatchCriteria
+		want  bool
+	}{
+		{"no filter", MatchCriteria{}, true},
+		{"exact match", MatchCriteria{Namespace: "kube-system"}, true},
+		{"exact mismatch", MatchCriteria{Namespace: "default"}, false},
+		{"pattern match", MatchCriteria{NamespacePattern: "^kube-"}, true},
+		{"pattern mismatch", MatchCriteria{NamespacePattern: "^default"}, false},
+		{"invalid regex", MatchCriteria{NamespacePattern: "[invalid"}, false},
+		{"both match", MatchCriteria{Namespace: "kube-system", NamespacePattern: "^kube-"}, true},
+		{"ns match pattern mismatch", MatchCriteria{Namespace: "kube-system", NamespacePattern: "^default"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesNamespace(node, tt.match)
+			if got != tt.want {
+				t.Errorf("matchesNamespace = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// matchesName
+// ---------------------------------------------------------------------------
+
+func TestMatchesName(t *testing.T) {
+	node := &graph.Node{Name: "web-deploy-abc123"}
+
+	tests := []struct {
+		name  string
+		match MatchCriteria
+		want  bool
+	}{
+		{"no pattern", MatchCriteria{}, true},
+		{"matching pattern", MatchCriteria{NamePattern: "^web-"}, true},
+		{"non-matching", MatchCriteria{NamePattern: "^api-"}, false},
+		{"invalid regex", MatchCriteria{NamePattern: "[bad"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesName(node, tt.match)
+			if got != tt.want {
+				t.Errorf("matchesName = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// matchesLabels
+// ---------------------------------------------------------------------------
+
+func TestMatchesLabels(t *testing.T) {
+	node := &graph.Node{Labels: map[string]string{"app": "web", "env": "prod"}}
+
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{"nil labels", nil, true},
+		{"empty labels", map[string]string{}, true},
+		{"matching single", map[string]string{"app": "web"}, true},
+		{"matching both", map[string]string{"app": "web", "env": "prod"}, true},
+		{"value mismatch", map[string]string{"app": "api"}, false},
+		{"missing key", map[string]string{"tier": "frontend"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesLabels(node, tt.labels)
+			if got != tt.want {
+				t.Errorf("matchesLabels = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// evaluateCondition
+// ---------------------------------------------------------------------------
+
+func TestEvaluateCondition(t *testing.T) {
+	g := buildTestGraph()
+
+	// Retrieve nodes from the graph for tests.
+	sa := g.FindNode(graph.NodeServiceAccount, "default", "my-sa")
+	saSys := g.FindNode(graph.NodeServiceAccount, "kube-system", "system-sa")
+	wl := g.FindNode(graph.NodeWorkload, "default", "web-deploy")
+	wlSafe := g.FindNode(graph.NodeWorkload, "default", "safe-deploy")
+	role := g.FindNode(graph.NodeRole, "", "cluster-admin")
+	nsRole := g.FindNode(graph.NodeRole, "default", "my-role")
+
+	tests := []struct {
+		name string
+		node *graph.Node
+		cond CheckCondition
+		want bool
+	}{
+		// HasLabel
+		{
+			name: "HasLabel present",
+			node: sa,
+			cond: CheckCondition{HasLabel: "app"},
+			want: true,
+		},
+		{
+			name: "HasLabel absent",
+			node: sa,
+			cond: CheckCondition{HasLabel: "nonexistent"},
+			want: false,
+		},
+
+		// MissingLabel
+		{
+			name: "MissingLabel missing",
+			node: saSys,
+			cond: CheckCondition{MissingLabel: "app"},
+			want: true,
+		},
+		{
+			name: "MissingLabel present",
+			node: sa,
+			cond: CheckCondition{MissingLabel: "app"},
+			want: false,
+		},
+
+		// LabelEquals
+		{
+			name: "LabelEquals match",
+			node: sa,
+			cond: CheckCondition{LabelEquals: map[string]string{"app": "web", "env": "prod"}},
+			want: true,
+		},
+		{
+			name: "LabelEquals mismatch",
+			node: sa,
+			cond: CheckCondition{LabelEquals: map[string]string{"app": "api"}},
+			want: false,
+		},
+
+		// LabelNotEquals
+		{
+			name: "LabelNotEquals true",
+			node: sa,
+			cond: CheckCondition{LabelNotEquals: map[string]string{"app": "api"}},
+			want: true,
+		},
+		{
+			name: "LabelNotEquals false",
+			node: sa,
+			cond: CheckCondition{LabelNotEquals: map[string]string{"app": "web"}},
+			want: false,
+		},
+
+		// HasCloudIdentity
+		{
+			name: "HasCloudIdentity true",
+			node: sa,
+			cond: CheckCondition{HasCloudIdentity: boolPtr(true)},
+			want: true,
+		},
+		{
+			name: "HasCloudIdentity false (wants true)",
+			node: saSys,
+			cond: CheckCondition{HasCloudIdentity: boolPtr(true)},
+			want: false,
+		},
+		{
+			name: "HasCloudIdentity false (wants false)",
+			node: saSys,
+			cond: CheckCondition{HasCloudIdentity: boolPtr(false)},
+			want: true,
+		},
+
+		// HasSecurityContext - privileged
+		{
+			name: "SecurityContext privileged true",
+			node: wl,
+			cond: CheckCondition{HasSecurityContext: &SecurityContext{Privileged: boolPtr(true)}},
+			want: true,
+		},
+		{
+			name: "SecurityContext privileged false (no psc)",
+			node: wlSafe,
+			cond: CheckCondition{HasSecurityContext: &SecurityContext{Privileged: boolPtr(true)}},
+			want: false,
+		},
+
+		// HasSecurityContext - hostNetwork
+		{
+			name: "SecurityContext hostNetwork true",
+			node: wl,
+			cond: CheckCondition{HasSecurityContext: &SecurityContext{HostNetwork: boolPtr(true)}},
+			want: true,
+		},
+		{
+			name: "SecurityContext hostNetwork false mismatch",
+			node: wl,
+			cond: CheckCondition{HasSecurityContext: &SecurityContext{HostNetwork: boolPtr(false)}},
+			want: false,
+		},
+
+		// HasSecurityContext - hostPID
+		{
+			name: "SecurityContext hostPID false match",
+			node: wl,
+			cond: CheckCondition{HasSecurityContext: &SecurityContext{HostPID: boolPtr(false)}},
+			want: true,
+		},
+
+		// HasSecurityContext - runAsRoot
+		{
+			name: "SecurityContext runAsRoot true",
+			node: wl,
+			cond: CheckCondition{HasSecurityContext: &SecurityContext{RunAsRoot: boolPtr(true)}},
+			want: true,
+		},
+
+		// HasSecurityContext - allowPrivilegeEscalation
+		{
+			name: "SecurityContext allowPrivilegeEscalation true",
+			node: wl,
+			cond: CheckCondition{HasSecurityContext: &SecurityContext{AllowPrivilegeEscalation: boolPtr(true)}},
+			want: true,
+		},
+
+		// HasSecurityContext - capabilities
+		{
+			name: "SecurityContext hasCapability match",
+			node: wl,
+			cond: CheckCondition{HasSecurityContext: &SecurityContext{HasCapability: []string{"NET_ADMIN"}}},
+			want: true,
+		},
+		{
+			name: "SecurityContext hasCapability missing",
+			node: wl,
+			cond: CheckCondition{HasSecurityContext: &SecurityContext{HasCapability: []string{"NET_RAW"}}},
+			want: false,
+		},
+
+		// HasSecurityContext - hasHostPath
+		{
+			name: "SecurityContext hasHostPath true",
+			node: wl,
+			cond: CheckCondition{HasSecurityContext: &SecurityContext{HasHostPath: boolPtr(true)}},
+			want: true,
+		},
+		{
+			name: "SecurityContext hasHostPath false (has paths)",
+			node: wl,
+			cond: CheckCondition{HasSecurityContext: &SecurityContext{HasHostPath: boolPtr(false)}},
+			want: false,
+		},
+
+		// HasSecurityContext - only pod-level fields, no container fields
+		{
+			name: "SecurityContext pod-level only (hostIPC false)",
+			node: wl,
+			cond: CheckCondition{HasSecurityContext: &SecurityContext{HostIPC: boolPtr(false)}},
+			want: true,
+		},
+
+		// HasRBACBinding
+		{
+			name: "HasRBACBinding true (has edge)",
+			node: sa,
+			cond: CheckCondition{HasRBACBinding: boolPtr(true)},
+			want: true,
+		},
+		{
+			name: "HasRBACBinding false (has edge)",
+			node: sa,
+			cond: CheckCondition{HasRBACBinding: boolPtr(false)},
+			want: false,
+		},
+		{
+			name: "HasRBACBinding true (no edge)",
+			node: saSys,
+			cond: CheckCondition{HasRBACBinding: boolPtr(true)},
+			want: false,
+		},
+
+		// BindsToRole
+		{
+			name: "BindsToRole matching",
+			node: sa,
+			cond: CheckCondition{BindsToRole: "cluster-admin"},
+			want: true,
+		},
+		{
+			name: "BindsToRole not matching",
+			node: sa,
+			cond: CheckCondition{BindsToRole: "other-role"},
+			want: false,
+		},
+		{
+			name: "BindsToRole no edges",
+			node: saSys,
+			cond: CheckCondition{BindsToRole: "cluster-admin"},
+			want: false,
+		},
+
+		// IsClusterRole
+		{
+			name: "IsClusterRole true",
+			node: role,
+			cond: CheckCondition{IsClusterRole: boolPtr(true)},
+			want: true,
+		},
+		{
+			name: "IsClusterRole false",
+			node: nsRole,
+			cond: CheckCondition{IsClusterRole: boolPtr(true)},
+			want: false,
+		},
+
+		// And composite
+		{
+			name: "And both true",
+			node: sa,
+			cond: CheckCondition{And: []CheckCondition{
+				{HasLabel: "app"},
+				{HasCloudIdentity: boolPtr(true)},
+			}},
+			want: true,
+		},
+		{
+			name: "And one false",
+			node: sa,
+			cond: CheckCondition{And: []CheckCondition{
+				{HasLabel: "app"},
+				{HasCloudIdentity: boolPtr(false)},
+			}},
+			want: false,
+		},
+
+		// Or composite
+		{
+			name: "Or one true",
+			node: saSys,
+			cond: CheckCondition{Or: []CheckCondition{
+				{HasLabel: "app"},
+				{HasLabel: "component"},
+			}},
+			want: true,
+		},
+		{
+			name: "Or none true",
+			node: saSys,
+			cond: CheckCondition{Or: []CheckCondition{
+				{HasLabel: "app"},
+				{HasLabel: "env"},
+			}},
+			want: false,
+		},
+
+		// Not composite
+		{
+			name: "Not inverts true to false",
+			node: sa,
+			cond: CheckCondition{Not: &CheckCondition{HasLabel: "app"}},
+			want: false,
+		},
+		{
+			name: "Not inverts false to true",
+			node: sa,
+			cond: CheckCondition{Not: &CheckCondition{HasLabel: "missing"}},
+			want: true,
+		},
+
+		// Default (no condition fields set)
+		{
+			name: "empty condition returns false",
+			node: sa,
+			cond: CheckCondition{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evaluateCondition(g, tt.node, tt.cond)
+			if got != tt.want {
+				t.Errorf("evaluateCondition = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// checkSecurityContext
+// ---------------------------------------------------------------------------
+
+func TestCheckSecurityContext(t *testing.T) {
+	nodeWithPSC := &graph.Node{
+		Metadata: graph.NodeMetadata{
+			PodSecurityContext: &graph.PodSecurityContext{
+				HostNetwork: true,
+				Containers: []graph.ContainerSecurityInfo{
+					{
+						Name:                     "c1",
+						Privileged:               false,
+						RunAsRoot:                false,
+						AllowPrivilegeEscalation: false,
+						Capabilities:             []string{"NET_ADMIN"},
+					},
+				},
+			},
+		},
+	}
+
+	nodeNoPSC := &graph.Node{}
+
+	tests := []struct {
+		name string
+		node *graph.Node
+		sc   *SecurityContext
+		want bool
+	}{
+		{"nil psc", nodeNoPSC, &SecurityContext{}, false},
+		{"hostNetwork match", nodeWithPSC, &SecurityContext{HostNetwork: boolPtr(true)}, true},
+		{"hostNetwork mismatch", nodeWithPSC, &SecurityContext{HostNetwork: boolPtr(false)}, false},
+		{"privileged false match", nodeWithPSC, &SecurityContext{Privileged: boolPtr(false)}, true},
+		{"privileged true no match", nodeWithPSC, &SecurityContext{Privileged: boolPtr(true)}, false},
+		{"capability found", nodeWithPSC, &SecurityContext{HasCapability: []string{"NET_ADMIN"}}, true},
+		{"capability not found", nodeWithPSC, &SecurityContext{HasCapability: []string{"SYS_ADMIN"}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkSecurityContext(tt.node, tt.sc)
+			if got != tt.want {
+				t.Errorf("checkSecurityContext = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// checkMissingSecurityField
+// ---------------------------------------------------------------------------
+
+func TestCheckMissingSecurityField(t *testing.T) {
+	nodeNoPSC := &graph.Node{}
+
+	nodeWithCtx := &graph.Node{
+		Metadata: graph.NodeMetadata{
+			PodSecurityContext: &graph.PodSecurityContext{
+				Containers: []graph.ContainerSecurityInfo{
+					{
+						HasSecurityContext:     true,
+						RunAsRoot:              false,
+						ReadOnlyRootFilesystem: true,
+						Capabilities:           []string{"NET_ADMIN"},
+					},
+				},
+			},
+		},
+	}
+
+	nodeNoCtx := &graph.Node{
+		Metadata: graph.NodeMetadata{
+			PodSecurityContext: &graph.PodSecurityContext{
+				Containers: []graph.ContainerSecurityInfo{
+					{
+						HasSecurityContext:     false,
+						RunAsRoot:              true,
+						ReadOnlyRootFilesystem: false,
+						Capabilities:           nil,
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		node  *graph.Node
+		field string
+		want  bool
+	}{
+		{"nil psc", nodeNoPSC, "securitycontext", true},
+		{"securitycontext present", nodeWithCtx, "securitycontext", false},
+		{"securitycontext absent", nodeNoCtx, "securitycontext", true},
+		{"readonlyrootfilesystem present", nodeWithCtx, "readonlyrootfilesystem", false},
+		{"readonlyrootfilesystem absent", nodeNoCtx, "readonlyrootfilesystem", true},
+		{"capabilities present", nodeWithCtx, "capabilities", false},
+		{"capabilities absent", nodeNoCtx, "capabilities", true},
+		// runasnonroot: returns false when !RunAsRoot && HasSecurityContext
+		{"runasnonroot configured", nodeWithCtx, "runasnonroot", false},
+		// nodeNoCtx has RunAsRoot=true, HasSecurityContext=false => never hits the false return
+		{"runasnonroot not configured", nodeNoCtx, "runasnonroot", true},
+		{"unknown field", nodeWithCtx, "unknownfield", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkMissingSecurityField(tt.node, tt.field)
+			if got != tt.want {
+				t.Errorf("checkMissingSecurityField(%q) = %v, want %v", tt.field, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// createFinding
+// ---------------------------------------------------------------------------
+
+func TestCreateFinding(t *testing.T) {
+	check := CustomCheck{
+		ID:          "TST001",
+		Name:        "Test",
+		Category:    "security",
+		Severity:    "high",
+		Description: "desc",
+		Remediation: "fix it",
+		Metadata:    map[string]string{"key": "val"},
+	}
+	node := &graph.Node{
+		Type:      graph.NodeServiceAccount,
+		Namespace: "default",
+		Name:      "my-sa",
+	}
+
+	f := createFinding(check, node, "details here")
+
+	if f.CheckID != "TST001" {
+		t.Errorf("CheckID = %q", f.CheckID)
+	}
+	if f.Severity != "high" {
+		t.Errorf("Severity = %q", f.Severity)
+	}
+	if len(f.Affected) != 1 {
+		t.Fatalf("Affected len = %d", len(f.Affected))
+	}
+	a := f.Affected[0]
+	if a.Kind != string(graph.NodeServiceAccount) {
+		t.Errorf("Kind = %q", a.Kind)
+	}
+	if a.Namespace != "default" || a.Name != "my-sa" {
+		t.Errorf("Namespace/Name = %q/%q", a.Namespace, a.Name)
+	}
+	if a.Details != "details here" {
+		t.Errorf("Details = %q", a.Details)
+	}
+	if f.Metadata["key"] != "val" {
+		t.Errorf("Metadata = %v", f.Metadata)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getConditionDetails
+// ---------------------------------------------------------------------------
+
+func TestGetConditionDetails(t *testing.T) {
+	tests := []struct {
+		name string
+		cond CheckCondition
+		want string
+	}{
+		{"missing label", CheckCondition{MissingLabel: "app"}, "Missing label: app"},
+		{"has security context", CheckCondition{HasSecurityContext: &SecurityContext{}}, "Security context matches condition"},
+		{"missing security field", CheckCondition{MissingSecurityField: "runAsNonRoot"}, "Missing security field: runAsNonRoot"},
+		{"has cloud identity true", CheckCondition{HasCloudIdentity: boolPtr(true)}, "Has cloud identity binding"},
+		{"has cloud identity false", CheckCondition{HasCloudIdentity: boolPtr(false)}, "Missing cloud identity binding"},
+		{"binds to role", CheckCondition{BindsToRole: "admin"}, "Binds to role: admin"},
+		{"default", CheckCondition{HasLabel: "x"}, "Condition matched"},
+		{"empty", CheckCondition{}, "Condition matched"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getConditionDetails(tt.cond)
+			if got != tt.want {
+				t.Errorf("getConditionDetails = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RunCustomChecks - integration-style tests
+// ---------------------------------------------------------------------------
+
+func TestRunCustomChecks(t *testing.T) {
+	g := buildTestGraph()
+
+	t.Run("Exists condition", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "E001", Name: "SA exists", Category: "audit", Severity: "info",
+			Description: "Find SAs",
+			Match:       MatchCriteria{Kind: "ServiceAccount"},
+			Condition:   CheckCondition{Exists: boolPtr(true)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 2 { // my-sa + system-sa
+			t.Errorf("got %d findings, want 2", len(findings))
+		}
+	})
+
+	t.Run("Exists with namespace filter", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "E002", Name: "SA in default", Category: "audit", Severity: "info",
+			Description: "Find SAs in default",
+			Match:       MatchCriteria{Kind: "ServiceAccount", Namespace: "default"},
+			Condition:   CheckCondition{Exists: boolPtr(true)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+
+	t.Run("Exists with namespace pattern", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "E003", Name: "SA in kube-*", Category: "audit", Severity: "info",
+			Description: "Find SAs in kube namespaces",
+			Match:       MatchCriteria{Kind: "ServiceAccount", NamespacePattern: "^kube-"},
+			Condition:   CheckCondition{Exists: boolPtr(true)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+
+	t.Run("Exists with name pattern", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "E004", Name: "web workloads", Category: "audit", Severity: "info",
+			Description: "Find web workloads",
+			Match:       MatchCriteria{Kind: "Workload", NamePattern: "^web-"},
+			Condition:   CheckCondition{Exists: boolPtr(true)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+
+	t.Run("Exists with label filter", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "E005", Name: "app=web SAs", Category: "audit", Severity: "info",
+			Description: "Find app=web SAs",
+			Match:       MatchCriteria{Kind: "ServiceAccount", Labels: map[string]string{"app": "web"}},
+			Condition:   CheckCondition{Exists: boolPtr(true)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+
+	t.Run("NotExists - no matches triggers finding", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "N001", Name: "missing SCC", Category: "audit", Severity: "warning",
+			Description: "No SCC found",
+			Match:       MatchCriteria{Kind: "scc"},
+			Condition:   CheckCondition{NotExists: boolPtr(true)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+		if len(findings) == 1 && findings[0].Affected[0].Details != "No matching resources found" {
+			t.Errorf("unexpected details: %q", findings[0].Affected[0].Details)
+		}
+	})
+
+	t.Run("NotExists - matches exist so no finding", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "N002", Name: "missing SA", Category: "audit", Severity: "warning",
+			Description: "No SA found",
+			Match:       MatchCriteria{Kind: "ServiceAccount"},
+			Condition:   CheckCondition{NotExists: boolPtr(true)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 0 {
+			t.Errorf("got %d findings, want 0", len(findings))
+		}
+	})
+
+	t.Run("HasLabel condition", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "L001", Name: "SA with app label", Category: "audit", Severity: "info",
+			Description: "SA has app label",
+			Match:       MatchCriteria{Kind: "ServiceAccount"},
+			Condition:   CheckCondition{HasLabel: "app"},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+
+	t.Run("MissingLabel condition", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "L002", Name: "SA missing app label", Category: "audit", Severity: "info",
+			Description: "SA missing app",
+			Match:       MatchCriteria{Kind: "ServiceAccount"},
+			Condition:   CheckCondition{MissingLabel: "app"},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		// system-sa has no "app" label
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+
+	t.Run("HasSecurityContext privileged", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "S001", Name: "Privileged workload", Category: "security", Severity: "critical",
+			Description: "Privileged container",
+			Match:       MatchCriteria{Kind: "Workload"},
+			Condition:   CheckCondition{HasSecurityContext: &SecurityContext{Privileged: boolPtr(true)}},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		// web-deploy is privileged, safe-deploy has no PSC
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+
+	t.Run("MissingSecurityField", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "S002", Name: "Missing security context", Category: "security", Severity: "high",
+			Description: "No security context",
+			Match:       MatchCriteria{Kind: "Workload"},
+			Condition:   CheckCondition{MissingSecurityField: "securitycontext"},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		// safe-deploy has nil PSC (returns true), web-deploy has HasSecurityContext=true (returns false)
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+
+	t.Run("HasCloudIdentity", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "C001", Name: "SA with cloud identity", Category: "cloud", Severity: "info",
+			Description: "Cloud bound SA",
+			Match:       MatchCriteria{Kind: "ServiceAccount"},
+			Condition:   CheckCondition{HasCloudIdentity: boolPtr(true)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+
+	t.Run("HasRBACBinding", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "R001", Name: "SA with RBAC", Category: "rbac", Severity: "info",
+			Description: "Has RBAC binding",
+			Match:       MatchCriteria{Kind: "ServiceAccount"},
+			Condition:   CheckCondition{HasRBACBinding: boolPtr(true)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+
+	t.Run("IsClusterRole", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "R002", Name: "Cluster roles", Category: "rbac", Severity: "info",
+			Description: "Is cluster role",
+			Match:       MatchCriteria{Kind: "Role"},
+			Condition:   CheckCondition{IsClusterRole: boolPtr(true)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+
+	t.Run("And composite condition", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "A001", Name: "SA with app label and cloud", Category: "audit", Severity: "info",
+			Description: "Both conditions",
+			Match:       MatchCriteria{Kind: "ServiceAccount"},
+			Condition: CheckCondition{And: []CheckCondition{
+				{HasLabel: "app"},
+				{HasCloudIdentity: boolPtr(true)},
+			}},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+
+	t.Run("Or composite condition", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "O001", Name: "SA with app or component label", Category: "audit", Severity: "info",
+			Description: "Either label",
+			Match:       MatchCriteria{Kind: "ServiceAccount"},
+			Condition: CheckCondition{Or: []CheckCondition{
+				{HasLabel: "app"},
+				{HasLabel: "component"},
+			}},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		// my-sa has "app", system-sa has "component"
+		if len(findings) != 2 {
+			t.Errorf("got %d findings, want 2", len(findings))
+		}
+	})
+
+	t.Run("Not composite condition", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "NOT1", Name: "SA without cloud identity", Category: "audit", Severity: "info",
+			Description: "No cloud",
+			Match:       MatchCriteria{Kind: "ServiceAccount"},
+			Condition:   CheckCondition{Not: &CheckCondition{HasCloudIdentity: boolPtr(true)}},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		// system-sa has no cloud identity
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+
+	t.Run("CountGreaterThan triggers", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "CT01", Name: "Too many SAs", Category: "audit", Severity: "warning",
+			Description: "Many SAs",
+			Match:       MatchCriteria{Kind: "ServiceAccount"},
+			Condition:   CheckCondition{CountGreaterThan: intPtr(1)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		// 2 SAs > 1
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+		if len(findings) == 1 {
+			if !containsStr(findings[0].Affected[0].Details, "exceeds threshold") {
+				t.Errorf("details = %q", findings[0].Affected[0].Details)
+			}
+		}
+	})
+
+	t.Run("CountGreaterThan does not trigger", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "CT02", Name: "Not too many SAs", Category: "audit", Severity: "warning",
+			Description: "Few SAs",
+			Match:       MatchCriteria{Kind: "ServiceAccount"},
+			Condition:   CheckCondition{CountGreaterThan: intPtr(5)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 0 {
+			t.Errorf("got %d findings, want 0", len(findings))
+		}
+	})
+
+	t.Run("CountLessThan triggers", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "CT03", Name: "Too few cloud roles", Category: "audit", Severity: "warning",
+			Description: "Few cloud roles",
+			Match:       MatchCriteria{Kind: "cloudrole"},
+			Condition:   CheckCondition{CountLessThan: intPtr(3)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		// 1 cloud role < 3
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+		if len(findings) == 1 {
+			if !containsStr(findings[0].Affected[0].Details, "below threshold") {
+				t.Errorf("details = %q", findings[0].Affected[0].Details)
+			}
+		}
+	})
+
+	t.Run("CountLessThan does not trigger", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "CT04", Name: "Enough SAs", Category: "audit", Severity: "warning",
+			Description: "Enough SAs",
+			Match:       MatchCriteria{Kind: "ServiceAccount"},
+			Condition:   CheckCondition{CountLessThan: intPtr(1)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 0 {
+			t.Errorf("got %d findings, want 0", len(findings))
+		}
+	})
+
+	t.Run("Multiple checks in one config", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{
+			{
+				ID: "M001", Name: "Check 1", Category: "a", Severity: "info",
+				Description: "first",
+				Match:       MatchCriteria{Kind: "ServiceAccount"},
+				Condition:   CheckCondition{HasLabel: "app"},
+			},
+			{
+				ID: "M002", Name: "Check 2", Category: "b", Severity: "info",
+				Description: "second",
+				Match:       MatchCriteria{Kind: "Role"},
+				Condition:   CheckCondition{IsClusterRole: boolPtr(true)},
+			},
+		}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 2 {
+			t.Errorf("got %d findings, want 2", len(findings))
+		}
+	})
+
+	t.Run("No findings when nothing matches", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "Z001", Name: "Nonexistent", Category: "audit", Severity: "info",
+			Description: "nope",
+			Match:       MatchCriteria{Kind: "ServiceAccount", Namespace: "nonexistent"},
+			Condition:   CheckCondition{Exists: boolPtr(true)},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 0 {
+			t.Errorf("got %d findings, want 0", len(findings))
+		}
+	})
+
+	t.Run("LabelEquals condition via RunCustomChecks", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "LE01", Name: "Label equals", Category: "audit", Severity: "info",
+			Description: "label eq",
+			Match:       MatchCriteria{Kind: "ServiceAccount"},
+			Condition:   CheckCondition{LabelEquals: map[string]string{"env": "prod"}},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+
+	t.Run("LabelNotEquals condition via RunCustomChecks", func(t *testing.T) {
+		cfg := &CustomCheckConfig{Checks: []CustomCheck{{
+			ID: "LN01", Name: "Label not equals", Category: "audit", Severity: "info",
+			Description: "label neq",
+			Match:       MatchCriteria{Kind: "ServiceAccount"},
+			Condition:   CheckCondition{LabelNotEquals: map[string]string{"env": "prod"}},
+		}}}
+		findings := RunCustomChecks(g, cfg)
+		// system-sa does not have env=prod
+		if len(findings) != 1 {
+			t.Errorf("got %d findings, want 1", len(findings))
+		}
+	})
+}

--- a/pkg/collector/cloud/aws_test.go
+++ b/pkg/collector/cloud/aws_test.go
@@ -1,0 +1,554 @@
+package cloud
+
+import (
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+func TestExtractRoleName(t *testing.T) {
+	tests := []struct {
+		name    string
+		roleARN string
+		want    string
+	}{
+		{
+			name:    "standard ARN",
+			roleARN: "arn:aws:iam::123456789012:role/my-role",
+			want:    "my-role",
+		},
+		{
+			name:    "ARN with path",
+			roleARN: "arn:aws:iam::123456789012:role/path/to/my-role",
+			want:    "my-role",
+		},
+		{
+			name:    "just role name no slashes",
+			roleARN: "arn:aws:iam::123456789012:role",
+			want:    "role",
+		},
+		{
+			name:    "plain string no separators",
+			roleARN: "my-role",
+			want:    "my-role",
+		},
+		{
+			name:    "colon separated fallback",
+			roleARN: "prefix:my-role",
+			want:    "my-role",
+		},
+		{
+			name:    "empty string",
+			roleARN: "",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractRoleName(tt.roleARN)
+			if got != tt.want {
+				t.Errorf("extractRoleName(%q) = %q, want %q", tt.roleARN, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractAccountID(t *testing.T) {
+	tests := []struct {
+		name    string
+		roleARN string
+		want    string
+	}{
+		{
+			name:    "standard ARN",
+			roleARN: "arn:aws:iam::123456789012:role/my-role",
+			want:    "123456789012",
+		},
+		{
+			name:    "too few parts",
+			roleARN: "arn:aws:iam",
+			want:    "",
+		},
+		{
+			name:    "empty string",
+			roleARN: "",
+			want:    "",
+		},
+		{
+			name:    "exactly 5 parts",
+			roleARN: "a:b:c:d:account-id",
+			want:    "account-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractAccountID(tt.roleARN)
+			if got != tt.want {
+				t.Errorf("extractAccountID(%q) = %q, want %q", tt.roleARN, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTrustPolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		doc     string
+		wantNil bool
+		wantLen int
+	}{
+		{
+			name:    "invalid JSON",
+			doc:     "not json",
+			wantNil: true,
+		},
+		{
+			name:    "empty JSON",
+			doc:     "{}",
+			wantNil: false,
+			wantLen: 0,
+		},
+		{
+			name: "single string principal",
+			doc: `{
+				"Statement": [{
+					"Principal": {"Service": "ec2.amazonaws.com"}
+				}]
+			}`,
+			wantNil: false,
+			wantLen: 1,
+		},
+		{
+			name: "array principal",
+			doc: `{
+				"Statement": [{
+					"Principal": {"AWS": ["arn:aws:iam::111:root", "arn:aws:iam::222:root"]}
+				}]
+			}`,
+			wantNil: false,
+			wantLen: 2,
+		},
+		{
+			name: "multiple statements",
+			doc: `{
+				"Statement": [
+					{"Principal": {"Service": "ec2.amazonaws.com"}},
+					{"Principal": {"AWS": "arn:aws:iam::111:root"}}
+				]
+			}`,
+			wantNil: false,
+			wantLen: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTrustPolicy(tt.doc)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("parseTrustPolicy() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("parseTrustPolicy() = nil, want non-nil")
+			}
+			if len(got.TrustedEntities) != tt.wantLen {
+				t.Errorf("parseTrustPolicy() trusted entities len = %d, want %d", len(got.TrustedEntities), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestParsePolicyDocument(t *testing.T) {
+	tests := []struct {
+		name          string
+		doc           string
+		wantVersion   string
+		wantStmtCount int
+	}{
+		{
+			name:          "invalid JSON returns empty doc",
+			doc:           "not json",
+			wantVersion:   "",
+			wantStmtCount: 0,
+		},
+		{
+			name: "single statement with string action and resource",
+			doc: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": "s3:GetObject",
+					"Resource": "arn:aws:s3:::my-bucket/*"
+				}]
+			}`,
+			wantVersion:   "2012-10-17",
+			wantStmtCount: 1,
+		},
+		{
+			name: "statement with array actions and resources",
+			doc: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Sid": "AllowS3",
+					"Effect": "Allow",
+					"Action": ["s3:GetObject", "s3:PutObject"],
+					"Resource": ["arn:aws:s3:::bucket1/*", "arn:aws:s3:::bucket2/*"]
+				}]
+			}`,
+			wantVersion:   "2012-10-17",
+			wantStmtCount: 1,
+		},
+		{
+			name: "multiple statements",
+			doc: `{
+				"Version": "2012-10-17",
+				"Statement": [
+					{"Effect": "Allow", "Action": "*", "Resource": "*"},
+					{"Effect": "Deny", "Action": "iam:*", "Resource": "*"}
+				]
+			}`,
+			wantVersion:   "2012-10-17",
+			wantStmtCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parsePolicyDocument(tt.doc)
+			if got == nil {
+				t.Fatal("parsePolicyDocument() returned nil")
+			}
+			if got.Version != tt.wantVersion {
+				t.Errorf("Version = %q, want %q", got.Version, tt.wantVersion)
+			}
+			if len(got.Statement) != tt.wantStmtCount {
+				t.Errorf("Statement count = %d, want %d", len(got.Statement), tt.wantStmtCount)
+			}
+		})
+	}
+}
+
+func TestParsePolicyDocumentActions(t *testing.T) {
+	doc := `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["s3:GetObject", "s3:PutObject"],
+			"Resource": "arn:aws:s3:::my-bucket/*"
+		}]
+	}`
+
+	got := parsePolicyDocument(doc)
+	if len(got.Statement) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(got.Statement))
+	}
+	stmt := got.Statement[0]
+	if len(stmt.Action) != 2 {
+		t.Errorf("expected 2 actions, got %d", len(stmt.Action))
+	}
+	if len(stmt.Resource) != 1 {
+		t.Errorf("expected 1 resource, got %d", len(stmt.Resource))
+	}
+}
+
+func TestToStringSlice(t *testing.T) {
+	tests := []struct {
+		name string
+		v    interface{}
+		want []string
+	}{
+		{
+			name: "string input",
+			v:    "hello",
+			want: []string{"hello"},
+		},
+		{
+			name: "slice of interfaces",
+			v:    []interface{}{"a", "b", "c"},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "slice with non-string ignored",
+			v:    []interface{}{"a", 42, "b"},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "nil input",
+			v:    nil,
+			want: nil,
+		},
+		{
+			name: "unsupported type",
+			v:    123,
+			want: nil,
+		},
+		{
+			name: "empty slice",
+			v:    []interface{}{},
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toStringSlice(tt.v)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("toStringSlice() = %v, want nil", got)
+				}
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("toStringSlice() len = %d, want %d", len(got), len(tt.want))
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("toStringSlice()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestIsAdminPolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  *PolicyDocument
+		want bool
+	}{
+		{
+			name: "admin policy - star action and star resource",
+			doc: &PolicyDocument{
+				Statement: []Statement{{
+					Effect:   "Allow",
+					Action:   []string{"*"},
+					Resource: []string{"*"},
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "not admin - star action but specific resource",
+			doc: &PolicyDocument{
+				Statement: []Statement{{
+					Effect:   "Allow",
+					Action:   []string{"*"},
+					Resource: []string{"arn:aws:s3:::my-bucket"},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "not admin - specific action and star resource",
+			doc: &PolicyDocument{
+				Statement: []Statement{{
+					Effect:   "Allow",
+					Action:   []string{"s3:GetObject"},
+					Resource: []string{"*"},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "not admin - deny effect",
+			doc: &PolicyDocument{
+				Statement: []Statement{{
+					Effect:   "Deny",
+					Action:   []string{"*"},
+					Resource: []string{"*"},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "empty statements",
+			doc:  &PolicyDocument{Statement: []Statement{}},
+			want: false,
+		},
+		{
+			name: "admin in second statement",
+			doc: &PolicyDocument{
+				Statement: []Statement{
+					{Effect: "Allow", Action: []string{"s3:GetObject"}, Resource: []string{"*"}},
+					{Effect: "Allow", Action: []string{"*"}, Resource: []string{"*"}},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAdminPolicy(tt.doc)
+			if got != tt.want {
+				t.Errorf("isAdminPolicy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsAWSManagedAdmin(t *testing.T) {
+	tests := []struct {
+		name      string
+		policyARN string
+		want      bool
+	}{
+		{"AdministratorAccess", "arn:aws:iam::aws:policy/AdministratorAccess", true},
+		{"PowerUserAccess", "arn:aws:iam::aws:policy/PowerUserAccess", true},
+		{"IAMFullAccess", "arn:aws:iam::aws:policy/IAMFullAccess", true},
+		{"ReadOnlyAccess", "arn:aws:iam::aws:policy/ReadOnlyAccess", false},
+		{"custom policy", "arn:aws:iam::123456789012:policy/my-policy", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAWSManagedAdmin(tt.policyARN)
+			if got != tt.want {
+				t.Errorf("isAWSManagedAdmin(%q) = %v, want %v", tt.policyARN, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyAWSResource(t *testing.T) {
+	tests := []struct {
+		name        string
+		resourceARN string
+		want        string
+	}{
+		{"wildcard", "*", "all-resources"},
+		{"s3 bucket", "arn:aws:s3:::my-bucket", "s3-bucket"},
+		{"secretsmanager", "arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret", "secrets-manager"},
+		{"ssm", "arn:aws:ssm:us-east-1:123456789012:parameter/myp", "ssm-parameter"},
+		{"kms", "arn:aws:kms:us-east-1:123456789012:key/my-key", "kms-key"},
+		{"dynamodb", "arn:aws:dynamodb:us-east-1:123456789012:table/mytable", "dynamodb-table"},
+		{"rds", "arn:aws:rds:us-east-1:123456789012:db:mydb", "rds-database"},
+		{"ec2", "arn:aws:ec2:us-east-1:123456789012:instance/i-1234", "ec2-instance"},
+		{"lambda", "arn:aws:lambda:us-east-1:123456789012:function:myfn", "lambda-function"},
+		{"ecs", "arn:aws:ecs:us-east-1:123456789012:service/mycluster/mysvc", "ecs-service"},
+		{"eks", "arn:aws:eks:us-east-1:123456789012:cluster/mycluster", "eks-cluster"},
+		{"sqs", "arn:aws:sqs:us-east-1:123456789012:myqueue", "sqs-queue"},
+		{"sns", "arn:aws:sns:us-east-1:123456789012:mytopic", "sns-topic"},
+		{"iam", "arn:aws:iam::123456789012:role/myrole", "iam-resource"},
+		{"sts", "arn:aws:sts::123456789012:assumed-role/myrole/session", "sts-resource"},
+		{"unknown service", "arn:aws:elasticache:us-east-1:123456789012:cluster:mycluster", "elasticache"},
+		{"too few parts", "arn:aws", "unknown"},
+		{"empty string", "", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyAWSResource(tt.resourceARN)
+			if got != tt.want {
+				t.Errorf("classifyAWSResource(%q) = %q, want %q", tt.resourceARN, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeActions(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []string
+		new      []string
+		wantLen  int
+	}{
+		{
+			name:     "no overlap",
+			existing: []string{"s3:GetObject"},
+			new:      []string{"s3:PutObject"},
+			wantLen:  2,
+		},
+		{
+			name:     "full overlap",
+			existing: []string{"s3:GetObject"},
+			new:      []string{"s3:GetObject"},
+			wantLen:  1,
+		},
+		{
+			name:     "partial overlap",
+			existing: []string{"s3:GetObject", "s3:PutObject"},
+			new:      []string{"s3:PutObject", "s3:DeleteObject"},
+			wantLen:  3,
+		},
+		{
+			name:     "empty existing",
+			existing: []string{},
+			new:      []string{"s3:GetObject"},
+			wantLen:  1,
+		},
+		{
+			name:     "empty new",
+			existing: []string{"s3:GetObject"},
+			new:      []string{},
+			wantLen:  1,
+		},
+		{
+			name:     "both empty",
+			existing: []string{},
+			new:      []string{},
+			wantLen:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeActions(tt.existing, tt.new)
+			if len(got) != tt.wantLen {
+				t.Errorf("mergeActions() len = %d, want %d; got %v", len(got), tt.wantLen, got)
+			}
+		})
+	}
+}
+
+func TestClassifyAWSSeverity(t *testing.T) {
+	tests := []struct {
+		name         string
+		actions      []string
+		resourceType string
+		want         graph.Severity
+	}{
+		{"delegates to ClassifyCloudSeverity critical", []string{"*"}, "s3", graph.SeverityCritical},
+		{"delegates to ClassifyCloudSeverity medium", []string{"logs:Describe"}, "logs", graph.SeverityMedium},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyAWSSeverity(tt.actions, tt.resourceType)
+			if got != tt.want {
+				t.Errorf("ClassifyAWSSeverity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSafeString(t *testing.T) {
+	tests := []struct {
+		name string
+		s    *string
+		want string
+	}{
+		{"nil pointer", nil, ""},
+		{"non-nil pointer", strPtr("hello"), "hello"},
+		{"empty string pointer", strPtr(""), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := safeString(tt.s)
+			if got != tt.want {
+				t.Errorf("safeString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/pkg/collector/cloud/azure_test.go
+++ b/pkg/collector/cloud/azure_test.go
@@ -1,0 +1,217 @@
+package cloud
+
+import (
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+func TestIsAzureAdminRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		roleName string
+		want     bool
+	}{
+		{"Owner", "Owner", true},
+		{"Contributor", "Contributor", true},
+		{"User Access Administrator", "User Access Administrator", true},
+		{"Global Administrator", "Global Administrator", true},
+		{"Privileged Role Administrator", "Privileged Role Administrator", true},
+		{"Reader", "Reader", false},
+		{"Storage Blob Data Reader", "Storage Blob Data Reader", false},
+		{"empty string", "", false},
+		{"case sensitive - owner lowercase", "owner", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAzureAdminRole(tt.roleName)
+			if got != tt.want {
+				t.Errorf("isAzureAdminRole(%q) = %v, want %v", tt.roleName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyAzureAction(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		want   string
+	}{
+		{"storage action", "Microsoft.Storage/storageAccounts/read", "storage-account"},
+		{"keyvault action", "Microsoft.KeyVault/vaults/read", "key-vault"},
+		{"sql action", "Microsoft.Sql/servers/databases/read", "sql-database"},
+		{"compute action", "Microsoft.Compute/virtualMachines/read", "virtual-machine"},
+		{"container service", "Microsoft.ContainerService/managedClusters/read", "aks-cluster"},
+		{"web action", "Microsoft.Web/sites/read", "app-service"},
+		{"service bus", "Microsoft.ServiceBus/namespaces/read", "service-bus"},
+		{"event hub", "Microsoft.EventHub/namespaces/read", "event-hub"},
+		{"cosmos db", "Microsoft.CosmosDB/databaseAccounts/read", "cosmos-db"},
+		{"authorization", "Microsoft.Authorization/roleAssignments/read", "iam-resource"},
+		{"unknown action", "Microsoft.Network/virtualNetworks/read", "azure-resource"},
+		{"wildcard", "*", "azure-resource"},
+		{"empty string", "", "azure-resource"},
+		{"case insensitive", "MICROSOFT.STORAGE/storageAccounts/read", "storage-account"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyAzureAction(tt.action)
+			if got != tt.want {
+				t.Errorf("classifyAzureAction(%q) = %q, want %q", tt.action, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyAzureActionSeverity(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		want   graph.Severity
+	}{
+		{"wildcard star", "*", graph.SeverityCritical},
+		{"wildcard star-slash-star", "*/*", graph.SeverityCritical},
+		{"authorization action", "Microsoft.Authorization/roleAssignments/write", graph.SeverityCritical},
+		{"keyvault write", "Microsoft.KeyVault/vaults/secrets/write", graph.SeverityCritical},
+		{"keyvault secrets read", "Microsoft.KeyVault/vaults/secrets/read", graph.SeverityCritical},
+		{"storage write", "Microsoft.Storage/storageAccounts/write", graph.SeverityHigh},
+		{"compute delete", "Microsoft.Compute/virtualMachines/delete", graph.SeverityHigh},
+		{"action verb", "Microsoft.Compute/virtualMachines/start/action", graph.SeverityHigh},
+		{"read action", "Microsoft.Storage/storageAccounts/read", graph.SeverityMedium},
+		{"list action", "Microsoft.Resources/subscriptions/resourceGroups/read", graph.SeverityMedium},
+		{"empty string", "", graph.SeverityMedium},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyAzureActionSeverity(tt.action)
+			if got != tt.want {
+				t.Errorf("classifyAzureActionSeverity(%q) = %v, want %v", tt.action, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeduplicateResources(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []ResourceAccess
+		wantLen int
+	}{
+		{
+			name:    "empty input",
+			input:   []ResourceAccess{},
+			wantLen: 0,
+		},
+		{
+			name:    "nil input",
+			input:   nil,
+			wantLen: 0,
+		},
+		{
+			name: "no duplicates",
+			input: []ResourceAccess{
+				{ResourceType: "storage-account", Actions: []string{"read"}, Severity: graph.SeverityMedium},
+				{ResourceType: "key-vault", Actions: []string{"read"}, Severity: graph.SeverityMedium},
+			},
+			wantLen: 2,
+		},
+		{
+			name: "duplicate resource types merged",
+			input: []ResourceAccess{
+				{ResourceType: "storage-account", Actions: []string{"read"}, Severity: graph.SeverityMedium},
+				{ResourceType: "storage-account", Actions: []string{"write"}, Severity: graph.SeverityHigh},
+			},
+			wantLen: 1,
+		},
+		{
+			name: "severity upgraded on merge",
+			input: []ResourceAccess{
+				{ResourceType: "storage-account", Actions: []string{"read"}, Severity: graph.SeverityMedium},
+				{ResourceType: "storage-account", Actions: []string{"write"}, Severity: graph.SeverityCritical},
+			},
+			wantLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deduplicateResources(tt.input)
+			if len(got) != tt.wantLen {
+				t.Errorf("deduplicateResources() len = %d, want %d", len(got), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestDeduplicateResourcesMergedActions(t *testing.T) {
+	input := []ResourceAccess{
+		{ResourceType: "storage-account", Actions: []string{"read"}, Severity: graph.SeverityMedium},
+		{ResourceType: "storage-account", Actions: []string{"write"}, Severity: graph.SeverityHigh},
+	}
+
+	got := deduplicateResources(input)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(got))
+	}
+	if len(got[0].Actions) != 2 {
+		t.Errorf("expected 2 merged actions, got %d: %v", len(got[0].Actions), got[0].Actions)
+	}
+	if got[0].Severity != graph.SeverityHigh {
+		t.Errorf("expected severity %v, got %v", graph.SeverityHigh, got[0].Severity)
+	}
+}
+
+func TestDeduplicateResourcesSeverityUpgrade(t *testing.T) {
+	tests := []struct {
+		name       string
+		sev1       graph.Severity
+		sev2       graph.Severity
+		wantResult graph.Severity
+	}{
+		{"medium then critical upgrades", graph.SeverityMedium, graph.SeverityCritical, graph.SeverityCritical},
+		{"medium then high upgrades", graph.SeverityMedium, graph.SeverityHigh, graph.SeverityHigh},
+		{"high then critical upgrades", graph.SeverityHigh, graph.SeverityCritical, graph.SeverityCritical},
+		{"critical then medium stays critical", graph.SeverityCritical, graph.SeverityMedium, graph.SeverityCritical},
+		{"high then medium stays high", graph.SeverityHigh, graph.SeverityMedium, graph.SeverityHigh},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := []ResourceAccess{
+				{ResourceType: "test", Actions: []string{"a"}, Severity: tt.sev1},
+				{ResourceType: "test", Actions: []string{"b"}, Severity: tt.sev2},
+			}
+			got := deduplicateResources(input)
+			if len(got) != 1 {
+				t.Fatalf("expected 1, got %d", len(got))
+			}
+			if got[0].Severity != tt.wantResult {
+				t.Errorf("severity = %v, want %v", got[0].Severity, tt.wantResult)
+			}
+		})
+	}
+}
+
+func TestSafeStringValue(t *testing.T) {
+	tests := []struct {
+		name string
+		s    *string
+		want string
+	}{
+		{"nil pointer", nil, ""},
+		{"non-nil pointer", strPtr("hello"), "hello"},
+		{"empty string pointer", strPtr(""), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := safeStringValue(tt.s)
+			if got != tt.want {
+				t.Errorf("safeStringValue() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/collector/cloud/cloud_test.go
+++ b/pkg/collector/cloud/cloud_test.go
@@ -1,0 +1,386 @@
+package cloud
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+func TestDetectProvider(t *testing.T) {
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		wantProvider Provider
+		wantValue    string
+	}{
+		{
+			name:         "nil annotations",
+			annotations:  nil,
+			wantProvider: "",
+			wantValue:    "",
+		},
+		{
+			name:         "empty annotations",
+			annotations:  map[string]string{},
+			wantProvider: "",
+			wantValue:    "",
+		},
+		{
+			name:         "AWS EKS annotation",
+			annotations:  map[string]string{"eks.amazonaws.com/role-arn": "arn:aws:iam::123456789012:role/my-role"},
+			wantProvider: ProviderAWS,
+			wantValue:    "arn:aws:iam::123456789012:role/my-role",
+		},
+		{
+			name:         "GCP GKE annotation",
+			annotations:  map[string]string{"iam.gke.io/gcp-service-account": "sa@project.iam.gserviceaccount.com"},
+			wantProvider: ProviderGCP,
+			wantValue:    "sa@project.iam.gserviceaccount.com",
+		},
+		{
+			name:         "Azure workload identity annotation",
+			annotations:  map[string]string{"azure.workload.identity/client-id": "client-id-123"},
+			wantProvider: ProviderAzure,
+			wantValue:    "client-id-123",
+		},
+		{
+			name: "unrelated annotations only",
+			annotations: map[string]string{
+				"app.kubernetes.io/name": "my-app",
+			},
+			wantProvider: "",
+			wantValue:    "",
+		},
+		{
+			name: "AWS takes precedence when multiple present",
+			annotations: map[string]string{
+				"eks.amazonaws.com/role-arn":         "arn:aws:iam::123456789012:role/my-role",
+				"iam.gke.io/gcp-service-account":    "sa@project.iam.gserviceaccount.com",
+				"azure.workload.identity/client-id":  "client-id-123",
+			},
+			wantProvider: ProviderAWS,
+			wantValue:    "arn:aws:iam::123456789012:role/my-role",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, value := DetectProvider(tt.annotations)
+			if provider != tt.wantProvider {
+				t.Errorf("DetectProvider() provider = %v, want %v", provider, tt.wantProvider)
+			}
+			if value != tt.wantValue {
+				t.Errorf("DetectProvider() value = %v, want %v", value, tt.wantValue)
+			}
+		})
+	}
+}
+
+func TestClassifyCloudSeverity(t *testing.T) {
+	tests := []struct {
+		name         string
+		actions      []string
+		resourceType string
+		want         graph.Severity
+	}{
+		{
+			name:         "wildcard action is critical",
+			actions:      []string{"*"},
+			resourceType: "s3-bucket",
+			want:         graph.SeverityCritical,
+		},
+		{
+			name:         "star-colon-star is critical",
+			actions:      []string{"*:*"},
+			resourceType: "unknown",
+			want:         graph.SeverityCritical,
+		},
+		{
+			name:         "iam wildcard is critical (admin action)",
+			actions:      []string{"iam:*"},
+			resourceType: "iam-resource",
+			want:         graph.SeverityCritical,
+		},
+		{
+			name:         "sts:AssumeRole is critical",
+			actions:      []string{"sts:AssumeRole"},
+			resourceType: "sts-resource",
+			want:         graph.SeverityCritical,
+		},
+		{
+			name:         "s3:GetObject matches s3:* admin pattern so critical",
+			actions:      []string{"s3:GetObject"},
+			resourceType: "s3-bucket",
+			want:         graph.SeverityCritical,
+		},
+		{
+			name:         "lambda:InvokeFunction matches lambda:* admin pattern so critical",
+			actions:      []string{"lambda:InvokeFunction"},
+			resourceType: "lambda-function",
+			want:         graph.SeverityCritical,
+		},
+		{
+			name:         "high risk resource type with s3 action matches admin",
+			actions:      []string{"s3:ListBuckets"},
+			resourceType: "secret",
+			want:         graph.SeverityCritical,
+		},
+		{
+			name:         "bigquery.tables.getData is high risk only",
+			actions:      []string{"bigquery.tables.getData"},
+			resourceType: "bigquery",
+			want:         graph.SeverityHigh,
+		},
+		{
+			name:         "high risk resource type elevates benign action",
+			actions:      []string{"logs:DescribeLogGroups"},
+			resourceType: "database",
+			want:         graph.SeverityHigh,
+		},
+		{
+			name:         "medium severity default",
+			actions:      []string{"logs:DescribeLogGroups"},
+			resourceType: "logs",
+			want:         graph.SeverityMedium,
+		},
+		{
+			name:         "empty actions with non-high-risk resource",
+			actions:      []string{},
+			resourceType: "logs",
+			want:         graph.SeverityMedium,
+		},
+		{
+			name:         "kms:Decrypt is admin/critical",
+			actions:      []string{"kms:Decrypt"},
+			resourceType: "kms-key",
+			want:         graph.SeverityCritical,
+		},
+		{
+			name:         "secretsmanager:GetSecretValue matches secretsmanager:* admin so critical",
+			actions:      []string{"secretsmanager:GetSecretValue"},
+			resourceType: "secrets-manager",
+			want:         graph.SeverityCritical,
+		},
+		{
+			name:         "GCP roles/owner is admin/critical",
+			actions:      []string{"roles/owner"},
+			resourceType: "gcp-resource",
+			want:         graph.SeverityCritical,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyCloudSeverity(tt.actions, tt.resourceType)
+			if got != tt.want {
+				t.Errorf("ClassifyCloudSeverity(%v, %q) = %v, want %v", tt.actions, tt.resourceType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewMultiCloudCollector(t *testing.T) {
+	mcc := NewMultiCloudCollector()
+	if mcc == nil {
+		t.Fatal("NewMultiCloudCollector() returned nil")
+	}
+	if mcc.collectors == nil {
+		t.Fatal("NewMultiCloudCollector() collectors map is nil")
+	}
+	if len(mcc.collectors) != 0 {
+		t.Errorf("NewMultiCloudCollector() collectors map should be empty, got %d", len(mcc.collectors))
+	}
+}
+
+type mockCollector struct {
+	provider Provider
+}
+
+func (m *mockCollector) Provider() Provider                                                          { return m.provider }
+func (m *mockCollector) CollectRole(_ context.Context, _ string) (*RoleInfo, error)                  { return nil, nil }
+func (m *mockCollector) GetResourceAccess(_ context.Context, _ *RoleInfo) ([]ResourceAccess, error)  { return nil, nil }
+
+func TestRegisterAndGetCollector(t *testing.T) {
+	mcc := NewMultiCloudCollector()
+
+	awsMock := &mockCollector{provider: ProviderAWS}
+	gcpMock := &mockCollector{provider: ProviderGCP}
+
+	mcc.Register(awsMock)
+	mcc.Register(gcpMock)
+
+	tests := []struct {
+		name     string
+		provider Provider
+		wantNil  bool
+	}{
+		{"get AWS collector", ProviderAWS, false},
+		{"get GCP collector", ProviderGCP, false},
+		{"get Azure collector (not registered)", ProviderAzure, true},
+		{"get empty provider", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mcc.GetCollector(tt.provider)
+			if tt.wantNil && got != nil {
+				t.Errorf("GetCollector(%q) = %v, want nil", tt.provider, got)
+			}
+			if !tt.wantNil && got == nil {
+				t.Errorf("GetCollector(%q) = nil, want non-nil", tt.provider)
+			}
+		})
+	}
+}
+
+func TestRegisterOverwrite(t *testing.T) {
+	mcc := NewMultiCloudCollector()
+	mock1 := &mockCollector{provider: ProviderAWS}
+	mock2 := &mockCollector{provider: ProviderAWS}
+
+	mcc.Register(mock1)
+	mcc.Register(mock2)
+
+	got := mcc.GetCollector(ProviderAWS)
+	if got.(*mockCollector) != mock2 {
+		t.Error("Register should overwrite existing collector for same provider")
+	}
+}
+
+func TestMatchAction(t *testing.T) {
+	tests := []struct {
+		name    string
+		action  string
+		pattern string
+		want    bool
+	}{
+		{"exact match", "s3:GetObject", "s3:GetObject", true},
+		{"no match", "s3:GetObject", "s3:PutObject", false},
+		{"wildcard prefix match", "s3:GetObject", "s3:*", true},
+		{"wildcard exact service", "iam:CreateRole", "iam:*", true},
+		{"wildcard no match", "ec2:RunInstances", "s3:*", false},
+		{"full wildcard", "anything", "*", true},
+		{"empty action vs pattern", "", "s3:*", false},
+		{"empty pattern", "s3:GetObject", "", false},
+		{"same string single char", "a", "a", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchAction(tt.action, tt.pattern)
+			if got != tt.want {
+				t.Errorf("matchAction(%q, %q) = %v, want %v", tt.action, tt.pattern, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsAdminAction(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		want   bool
+	}{
+		{"iam wildcard", "iam:*", true},
+		{"iam:CreateRole", "iam:CreateRole", true},
+		{"sts:AssumeRole", "sts:AssumeRole", true},
+		{"kms:Decrypt", "kms:Decrypt", true},
+		{"s3:GetObject matches s3:* so is admin", "s3:GetObject", true},
+		{"cloudwatch:GetMetricData is not admin", "cloudwatch:GetMetricData", false},
+		{"roles/owner", "roles/owner", true},
+		{"roles/editor", "roles/editor", true},
+		{"benign action", "logs:DescribeLogGroups", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAdminAction(tt.action)
+			if got != tt.want {
+				t.Errorf("isAdminAction(%q) = %v, want %v", tt.action, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsHighRiskAction(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		want   bool
+	}{
+		{"s3:GetObject", "s3:GetObject", true},
+		{"s3:PutObject", "s3:PutObject", true},
+		{"s3:DeleteObject", "s3:DeleteObject", true},
+		{"secretsmanager:GetSecretValue", "secretsmanager:GetSecretValue", true},
+		{"dynamodb:*", "dynamodb:*", true},
+		{"lambda:InvokeFunction", "lambda:InvokeFunction", true},
+		{"storage.objects.get", "storage.objects.get", true},
+		{"bigquery.tables.getData", "bigquery.tables.getData", true},
+		{"not high risk", "logs:DescribeLogGroups", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isHighRiskAction(tt.action)
+			if got != tt.want {
+				t.Errorf("isHighRiskAction(%q) = %v, want %v", tt.action, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsHighRiskResource(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType string
+		want         bool
+	}{
+		{"s3", "s3", true},
+		{"bucket", "bucket", true},
+		{"secret", "secret", true},
+		{"kms", "kms", true},
+		{"database", "database", true},
+		{"rds", "rds", true},
+		{"dynamodb", "dynamodb", true},
+		{"storage", "storage", true},
+		{"bigquery", "bigquery", true},
+		{"s3-bucket contains s3", "s3-bucket", true},
+		{"logs is not high risk", "logs", false},
+		{"ec2 is not high risk", "ec2", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isHighRiskResource(tt.resourceType)
+			if got != tt.want {
+				t.Errorf("isHighRiskResource(%q) = %v, want %v", tt.resourceType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      string
+		substr string
+		want   bool
+	}{
+		{"exact match", "hello", "hello", true},
+		{"substring", "hello world", "world", true},
+		{"not found", "hello", "xyz", false},
+		{"empty substr in non-empty", "hello", "", true},
+		{"empty both", "", "", true},
+		{"substr longer than string", "hi", "hello", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := contains(tt.s, tt.substr)
+			if got != tt.want {
+				t.Errorf("contains(%q, %q) = %v, want %v", tt.s, tt.substr, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/collector/cloud/gcp_test.go
+++ b/pkg/collector/cloud/gcp_test.go
@@ -1,0 +1,213 @@
+package cloud
+
+import (
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+func TestExtractGCPSAName(t *testing.T) {
+	tests := []struct {
+		name  string
+		email string
+		want  string
+	}{
+		{
+			name:  "standard GCP service account",
+			email: "my-sa@my-project.iam.gserviceaccount.com",
+			want:  "my-sa",
+		},
+		{
+			name:  "no @ sign",
+			email: "my-sa",
+			want:  "my-sa",
+		},
+		{
+			name:  "empty string",
+			email: "",
+			want:  "",
+		},
+		{
+			name:  "multiple @ signs",
+			email: "user@domain@extra",
+			want:  "user",
+		},
+		{
+			name:  "compute default SA",
+			email: "123456789-compute@developer.gserviceaccount.com",
+			want:  "123456789-compute",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractGCPSAName(tt.email)
+			if got != tt.want {
+				t.Errorf("extractGCPSAName(%q) = %q, want %q", tt.email, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractGCPProject(t *testing.T) {
+	tests := []struct {
+		name  string
+		email string
+		want  string
+	}{
+		{
+			name:  "standard GCP service account",
+			email: "my-sa@my-project.iam.gserviceaccount.com",
+			want:  "my-project",
+		},
+		{
+			name:  "no @ sign returns empty",
+			email: "my-sa",
+			want:  "",
+		},
+		{
+			name:  "non-gserviceaccount domain returns empty",
+			email: "user@gmail.com",
+			want:  "",
+		},
+		{
+			name:  "empty string",
+			email: "",
+			want:  "",
+		},
+		{
+			name:  "project with dashes",
+			email: "sa@my-cool-project-123.iam.gserviceaccount.com",
+			want:  "my-cool-project-123",
+		},
+		{
+			name:  "developer gserviceaccount domain returns empty",
+			email: "sa@developer.gserviceaccount.com",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractGCPProject(tt.email)
+			if got != tt.want {
+				t.Errorf("extractGCPProject(%q) = %q, want %q", tt.email, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyGCPResource(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		want     string
+	}{
+		{"GCS bucket by domain", "//storage.googleapis.com/my-bucket", "gcs-bucket"},
+		{"GCS bucket by gs://", "gs://my-bucket", "gcs-bucket"},
+		{"BigQuery", "//bigquery.googleapis.com/projects/p/datasets/d", "bigquery-dataset"},
+		{"Secret Manager", "//secretmanager.googleapis.com/projects/p/secrets/s", "secret-manager"},
+		{"Compute", "//compute.googleapis.com/projects/p/zones/z/instances/i", "compute-instance"},
+		{"GKE", "//container.googleapis.com/projects/p/locations/l/clusters/c", "gke-cluster"},
+		{"Cloud Functions", "//cloudfunctions.googleapis.com/projects/p/locations/l/functions/f", "cloud-function"},
+		{"Cloud Run", "//run.googleapis.com/projects/p/locations/l/services/s", "cloud-run"},
+		{"Pub/Sub", "//pubsub.googleapis.com/projects/p/topics/t", "pubsub-topic"},
+		{"Cloud SQL", "//cloudsql.googleapis.com/projects/p/instances/i", "cloud-sql"},
+		{"Cloud KMS", "//cloudkms.googleapis.com/projects/p/locations/l/keyRings/r/cryptoKeys/k", "cloud-kms"},
+		{"wildcard", "*", "gcp-resource"},
+		{"unknown resource", "//unknown.googleapis.com/foo", "gcp-resource"},
+		{"empty string", "", "gcp-resource"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyGCPResource(tt.resource)
+			if got != tt.want {
+				t.Errorf("classifyGCPResource(%q) = %q, want %q", tt.resource, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyGCPPermissionSeverity(t *testing.T) {
+	tests := []struct {
+		name        string
+		permissions []string
+		want        graph.Severity
+	}{
+		{
+			name:        "admin permission is critical",
+			permissions: []string{"resourcemanager.projects.admin"},
+			want:        graph.SeverityCritical,
+		},
+		{
+			name:        "setIamPolicy is critical",
+			permissions: []string{"resourcemanager.projects.setIamPolicy"},
+			want:        graph.SeverityCritical,
+		},
+		{
+			name:        "owner suffix is critical",
+			permissions: []string{"resourcemanager.projects.owner"},
+			want:        graph.SeverityCritical,
+		},
+		{
+			name:        "plain owner is critical",
+			permissions: []string{"owner"},
+			want:        graph.SeverityCritical,
+		},
+		{
+			name:        "secretmanager access is critical",
+			permissions: []string{"secretmanager.versions.access"},
+			want:        graph.SeverityCritical,
+		},
+		{
+			name:        "create permission is high",
+			permissions: []string{"compute.instances.create"},
+			want:        graph.SeverityHigh,
+		},
+		{
+			name:        "delete permission is high",
+			permissions: []string{"compute.instances.delete"},
+			want:        graph.SeverityHigh,
+		},
+		{
+			name:        "update permission is high",
+			permissions: []string{"compute.instances.update"},
+			want:        graph.SeverityHigh,
+		},
+		{
+			name:        "write permission is high",
+			permissions: []string{"logging.logEntries.write"},
+			want:        graph.SeverityHigh,
+		},
+		{
+			name:        "storage.objects.get is high",
+			permissions: []string{"storage.objects.get"},
+			want:        graph.SeverityHigh,
+		},
+		{
+			name:        "read-only permission is medium",
+			permissions: []string{"compute.instances.get", "compute.instances.list"},
+			want:        graph.SeverityMedium,
+		},
+		{
+			name:        "empty permissions is medium",
+			permissions: []string{},
+			want:        graph.SeverityMedium,
+		},
+		{
+			name:        "critical takes precedence over high",
+			permissions: []string{"compute.instances.create", "resourcemanager.projects.setIamPolicy"},
+			want:        graph.SeverityCritical,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyGCPPermissionSeverity(tt.permissions)
+			if got != tt.want {
+				t.Errorf("ClassifyGCPPermissionSeverity(%v) = %v, want %v", tt.permissions, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -1,0 +1,194 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/collector/distro"
+)
+
+func TestShouldIncludeNamespace_SingleNamespace(t *testing.T) {
+	opts := Options{
+		Namespace:     "production",
+		AllNamespaces: false,
+	}
+
+	cases := []struct {
+		ns   string
+		want bool
+	}{
+		{"production", true},
+		{"staging", false},
+		{"kube-system", false},
+		{"default", false},
+	}
+
+	for _, tc := range cases {
+		got := opts.ShouldIncludeNamespace(tc.ns)
+		if got != tc.want {
+			t.Errorf("ShouldIncludeNamespace(%q) with Namespace=%q: got %v, want %v",
+				tc.ns, opts.Namespace, got, tc.want)
+		}
+	}
+}
+
+func TestShouldIncludeNamespace_AllNamespacesIncludeSystem(t *testing.T) {
+	opts := Options{
+		AllNamespaces: true,
+		IncludeSystem: true,
+	}
+
+	cases := []struct {
+		ns   string
+		want bool
+	}{
+		{"production", true},
+		{"kube-system", true},
+		{"kube-public", true},
+		{"kube-node-lease", true},
+		{"openshift-monitoring", true},
+		{"default", true},
+	}
+
+	for _, tc := range cases {
+		got := opts.ShouldIncludeNamespace(tc.ns)
+		if got != tc.want {
+			t.Errorf("ShouldIncludeNamespace(%q) AllNamespaces+IncludeSystem: got %v, want %v",
+				tc.ns, got, tc.want)
+		}
+	}
+}
+
+func TestShouldIncludeNamespace_AllNamespacesExcludeSystem(t *testing.T) {
+	opts := Options{
+		AllNamespaces: true,
+		IncludeSystem: false,
+	}
+
+	cases := []struct {
+		ns   string
+		want bool
+	}{
+		{"production", true},
+		{"default", true},
+		{"my-app", true},
+		// System namespaces should be excluded
+		{"kube-system", false},
+		{"kube-public", false},
+		{"kube-node-lease", false},
+		{"openshift-monitoring", false},
+		{"cattle-system", false},
+		{"fleet-default", false},
+		{"rancher-monitoring", false},
+	}
+
+	for _, tc := range cases {
+		got := opts.ShouldIncludeNamespace(tc.ns)
+		if got != tc.want {
+			t.Errorf("ShouldIncludeNamespace(%q) AllNamespaces-ExcludeSystem: got %v, want %v",
+				tc.ns, got, tc.want)
+		}
+	}
+}
+
+func TestIsSystemNamespace_StandardNamespaces(t *testing.T) {
+	cases := []struct {
+		ns   string
+		want bool
+	}{
+		{"kube-system", true},
+		{"kube-public", true},
+		{"kube-node-lease", true},
+		{"default", false},
+		{"production", false},
+		{"my-namespace", false},
+		{"", false},
+	}
+
+	for _, tc := range cases {
+		got := IsSystemNamespace(tc.ns)
+		if got != tc.want {
+			t.Errorf("IsSystemNamespace(%q): got %v, want %v", tc.ns, got, tc.want)
+		}
+	}
+}
+
+func TestIsSystemNamespace_DistroPrefixes(t *testing.T) {
+	cases := []struct {
+		ns   string
+		want bool
+	}{
+		// OpenShift prefixes
+		{"openshift-monitoring", true},
+		{"openshift-ingress", true},
+		{"openshift-console", true},
+		// Rancher / RKE2 prefixes
+		{"cattle-system", true},
+		{"cattle-fleet-system", true},
+		{"fleet-default", true},
+		{"fleet-local", true},
+		{"rancher-monitoring", true},
+		{"rancher-operator-system", true},
+		// Non-system
+		{"openshift", false}, // exact match, not prefix
+		{"cattle", false},
+		{"fleet", false},
+		{"rancher", false},
+		{"my-openshift-app", false},
+	}
+
+	for _, tc := range cases {
+		got := IsSystemNamespace(tc.ns)
+		if got != tc.want {
+			t.Errorf("IsSystemNamespace(%q): got %v, want %v", tc.ns, got, tc.want)
+		}
+	}
+}
+
+func TestIsSystemNamespace_WithDistroProfile(t *testing.T) {
+	profile := distro.DistroProfile{
+		Platform:                "custom",
+		SystemNamespacePrefixes: []string{"custom-system-", "internal-"},
+	}
+
+	cases := []struct {
+		ns   string
+		want bool
+	}{
+		// Standard system namespaces still match
+		{"kube-system", true},
+		// Profile-specific prefixes
+		{"custom-system-foo", true},
+		{"internal-bar", true},
+		// Non-system
+		{"production", false},
+		{"custom-app", false},
+	}
+
+	for _, tc := range cases {
+		got := IsSystemNamespace(tc.ns, profile)
+		if got != tc.want {
+			t.Errorf("IsSystemNamespace(%q, profile): got %v, want %v", tc.ns, got, tc.want)
+		}
+	}
+}
+
+func TestIsSystemNamespace_EmptyAndEdgeCases(t *testing.T) {
+	cases := []struct {
+		ns   string
+		want bool
+	}{
+		{"", false},
+		{"k", false},
+		{"kube", false},
+		{"kube-", false},
+		{"KUBE-SYSTEM", false}, // case-sensitive
+		{"Kube-System", false},
+	}
+
+	for _, tc := range cases {
+		got := IsSystemNamespace(tc.ns)
+		if got != tc.want {
+			t.Errorf("IsSystemNamespace(%q): got %v, want %v", tc.ns, got, tc.want)
+		}
+	}
+}

--- a/pkg/collector/kubernetes_test.go
+++ b/pkg/collector/kubernetes_test.go
@@ -1,0 +1,505 @@
+package collector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/collector/distro"
+	"github.com/nelssec/identity-chain/pkg/graph"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// newTestCollector creates a KubernetesCollector with a fake client and given options.
+func newTestCollector(client *fake.Clientset, opts Options) *KubernetesCollector {
+	profile := distro.DistroProfile{
+		Platform:     "vanilla",
+		FeatureFlags: map[string]bool{},
+	}
+	return &KubernetesCollector{
+		client:        client,
+		options:       opts,
+		DistroProfile: &profile,
+	}
+}
+
+func TestGetNamespaces_SingleNamespace(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	opts := Options{
+		Namespace:     "production",
+		AllNamespaces: false,
+	}
+	c := newTestCollector(client, opts)
+
+	namespaces, err := c.getNamespaces(context.Background())
+	if err != nil {
+		t.Fatalf("getNamespaces returned error: %v", err)
+	}
+
+	if len(namespaces) != 1 || namespaces[0] != "production" {
+		t.Errorf("expected [production], got %v", namespaces)
+	}
+}
+
+func TestGetNamespaces_AllNamespaces(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "production"}},
+	)
+	opts := Options{AllNamespaces: true}
+	c := newTestCollector(client, opts)
+
+	namespaces, err := c.getNamespaces(context.Background())
+	if err != nil {
+		t.Fatalf("getNamespaces returned error: %v", err)
+	}
+
+	if len(namespaces) != 3 {
+		t.Errorf("expected 3 namespaces, got %d: %v", len(namespaces), namespaces)
+	}
+
+	nsSet := map[string]bool{}
+	for _, ns := range namespaces {
+		nsSet[ns] = true
+	}
+	for _, expected := range []string{"default", "kube-system", "production"} {
+		if !nsSet[expected] {
+			t.Errorf("expected namespace %q in results", expected)
+		}
+	}
+}
+
+func TestCollectServiceAccounts(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my-sa",
+				Namespace: "default",
+				Labels:    map[string]string{"app": "test"},
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cloud-sa",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"eks.amazonaws.com/role-arn": "arn:aws:iam::123456:role/my-role",
+				},
+			},
+		},
+	)
+	opts := Options{Namespace: "default"}
+	c := newTestCollector(client, opts)
+
+	builder := graph.NewBuilder()
+	err := c.collectServiceAccounts(context.Background(), builder, "default")
+	if err != nil {
+		t.Fatalf("collectServiceAccounts returned error: %v", err)
+	}
+
+	g := builder.Build()
+	saNodes := g.GetNodesByType(graph.NodeServiceAccount)
+	if len(saNodes) != 2 {
+		t.Fatalf("expected 2 service account nodes, got %d", len(saNodes))
+	}
+
+	// Verify cloud SA has the ARN populated
+	cloudSA := g.FindNode(graph.NodeServiceAccount, "default", "cloud-sa")
+	if cloudSA == nil {
+		t.Fatal("expected to find cloud-sa node")
+	}
+	if cloudSA.Metadata.CloudRoleARN != "arn:aws:iam::123456:role/my-role" {
+		t.Errorf("expected cloud role ARN, got %q", cloudSA.Metadata.CloudRoleARN)
+	}
+}
+
+func TestCollectRoles(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-reader",
+				Namespace: "default",
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+			},
+		},
+	)
+	opts := Options{Namespace: "default"}
+	c := newTestCollector(client, opts)
+
+	builder := graph.NewBuilder()
+	err := c.collectRoles(context.Background(), builder, "default")
+	if err != nil {
+		t.Fatalf("collectRoles returned error: %v", err)
+	}
+
+	g := builder.Build()
+	roleNode := g.FindNode(graph.NodeRole, "default", "pod-reader")
+	if roleNode == nil {
+		t.Fatal("expected to find pod-reader role node")
+	}
+	if roleNode.Metadata.IsClusterRole {
+		t.Error("expected role not to be a cluster role")
+	}
+	if len(roleNode.Metadata.Rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(roleNode.Metadata.Rules))
+	}
+	if roleNode.Metadata.Rules[0].Resources[0] != "pods" {
+		t.Errorf("expected resource 'pods', got %q", roleNode.Metadata.Rules[0].Resources[0])
+	}
+}
+
+func TestCollectClusterRoles(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster-admin-custom",
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"*"},
+					Resources: []string{"*"},
+					Verbs:     []string{"*"},
+				},
+			},
+		},
+	)
+	opts := Options{}
+	c := newTestCollector(client, opts)
+
+	builder := graph.NewBuilder()
+	err := c.collectClusterRoles(context.Background(), builder)
+	if err != nil {
+		t.Fatalf("collectClusterRoles returned error: %v", err)
+	}
+
+	g := builder.Build()
+	crNode := g.FindNode(graph.NodeRole, "", "cluster-admin-custom")
+	if crNode == nil {
+		t.Fatal("expected to find cluster-admin-custom node")
+	}
+	if !crNode.Metadata.IsClusterRole {
+		t.Error("expected cluster role to be marked as cluster role")
+	}
+}
+
+func TestCollectRoleBindings(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "read-pods-binding",
+				Namespace: "default",
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind: "Role",
+				Name: "pod-reader",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      "my-sa",
+					Namespace: "default",
+				},
+			},
+		},
+	)
+	opts := Options{Namespace: "default"}
+	c := newTestCollector(client, opts)
+
+	builder := graph.NewBuilder()
+
+	// Pre-add the SA and Role nodes so edges can be created
+	_ = builder.AddServiceAccount(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-sa", Namespace: "default"},
+	})
+	_ = builder.AddRole(&rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-reader", Namespace: "default"},
+		Rules:      []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}}},
+	})
+
+	err := c.collectRoleBindings(context.Background(), builder, "default")
+	if err != nil {
+		t.Fatalf("collectRoleBindings returned error: %v", err)
+	}
+
+	g := builder.Build()
+	saID := graph.GenerateNodeID(graph.NodeServiceAccount, "default", "my-sa")
+	edges := g.GetOutEdges(saID)
+	if len(edges) == 0 {
+		t.Error("expected at least one edge from service account to role")
+	}
+
+	foundBind := false
+	for _, e := range edges {
+		if e.Type == graph.EdgeBinds {
+			foundBind = true
+			if e.Metadata.BindingName != "read-pods-binding" {
+				t.Errorf("expected binding name 'read-pods-binding', got %q", e.Metadata.BindingName)
+			}
+		}
+	}
+	if !foundBind {
+		t.Error("expected a binds edge")
+	}
+}
+
+func TestCollectDeployments(t *testing.T) {
+	replicas := int32(3)
+	client := fake.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "web-app",
+				Namespace: "default",
+				Labels:    map[string]string{"app": "web"},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						ServiceAccountName: "web-sa",
+						Containers: []corev1.Container{
+							{Name: "web", Image: "nginx:latest"},
+						},
+					},
+				},
+			},
+		},
+	)
+	opts := Options{Namespace: "default"}
+	c := newTestCollector(client, opts)
+
+	builder := graph.NewBuilder()
+	err := c.collectDeployments(context.Background(), builder, "default")
+	if err != nil {
+		t.Fatalf("collectDeployments returned error: %v", err)
+	}
+
+	g := builder.Build()
+	workloads := g.GetNodesByType(graph.NodeWorkload)
+	if len(workloads) != 1 {
+		t.Fatalf("expected 1 workload node, got %d", len(workloads))
+	}
+
+	w := workloads[0]
+	if w.Name != "web-app" {
+		t.Errorf("expected workload name 'web-app', got %q", w.Name)
+	}
+	if w.Metadata.WorkloadKind != "Deployment" {
+		t.Errorf("expected workload kind 'Deployment', got %q", w.Metadata.WorkloadKind)
+	}
+	if w.Metadata.Replicas != 3 {
+		t.Errorf("expected 3 replicas, got %d", w.Metadata.Replicas)
+	}
+}
+
+func TestCollect_EndToEnd(t *testing.T) {
+	replicas := int32(1)
+	client := fake.NewSimpleClientset(
+		// Namespaces
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+
+		// ServiceAccount
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: "app-sa", Namespace: "default"},
+		},
+
+		// Role
+		&rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Name: "app-role", Namespace: "default"},
+			Rules: []rbacv1.PolicyRule{
+				{APIGroups: []string{""}, Resources: []string{"configmaps"}, Verbs: []string{"get", "list"}},
+			},
+		},
+
+		// RoleBinding
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "app-binding", Namespace: "default"},
+			RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "app-role"},
+			Subjects: []rbacv1.Subject{
+				{Kind: "ServiceAccount", Name: "app-sa", Namespace: "default"},
+			},
+		},
+
+		// Deployment
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "app-deploy", Namespace: "default"},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						ServiceAccountName: "app-sa",
+						Containers:         []corev1.Container{{Name: "app", Image: "app:v1"}},
+					},
+				},
+			},
+		},
+	)
+
+	opts := Options{AllNamespaces: true, IncludeSystem: false}
+	c := newTestCollector(client, opts)
+
+	builder := graph.NewBuilder()
+	err := c.Collect(context.Background(), builder)
+	if err != nil {
+		t.Fatalf("Collect returned error: %v", err)
+	}
+
+	g := builder.Build()
+
+	// Verify service account was collected (only from "default", kube-system excluded)
+	saNode := g.FindNode(graph.NodeServiceAccount, "default", "app-sa")
+	if saNode == nil {
+		t.Error("expected to find app-sa service account node")
+	}
+
+	// Verify deployment was collected
+	workloads := g.GetNodesByType(graph.NodeWorkload)
+	if len(workloads) == 0 {
+		t.Error("expected at least one workload node")
+	}
+
+	// Verify role was collected
+	roleNode := g.FindNode(graph.NodeRole, "default", "app-role")
+	if roleNode == nil {
+		t.Error("expected to find app-role node")
+	}
+
+	// Verify edges exist (SA -> Role binding)
+	saID := graph.GenerateNodeID(graph.NodeServiceAccount, "default", "app-sa")
+	outEdges := g.GetOutEdges(saID)
+	hasBindsEdge := false
+	for _, e := range outEdges {
+		if e.Type == graph.EdgeBinds {
+			hasBindsEdge = true
+		}
+	}
+	if !hasBindsEdge {
+		t.Error("expected a binds edge from app-sa")
+	}
+}
+
+func TestCollect_ExcludesSystemNamespaces(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: "system-sa", Namespace: "kube-system"},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-sa", Namespace: "default"},
+		},
+	)
+
+	opts := Options{AllNamespaces: true, IncludeSystem: false}
+	c := newTestCollector(client, opts)
+
+	builder := graph.NewBuilder()
+	err := c.Collect(context.Background(), builder)
+	if err != nil {
+		t.Fatalf("Collect returned error: %v", err)
+	}
+
+	g := builder.Build()
+
+	// system-sa in kube-system should NOT be collected
+	systemSA := g.FindNode(graph.NodeServiceAccount, "kube-system", "system-sa")
+	if systemSA != nil {
+		t.Error("expected system namespace SA to be excluded")
+	}
+
+	// user-sa in default should be collected
+	userSA := g.FindNode(graph.NodeServiceAccount, "default", "user-sa")
+	if userSA == nil {
+		t.Error("expected user namespace SA to be included")
+	}
+}
+
+func TestCollect_IncludesSystemNamespaces(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: "system-sa", Namespace: "kube-system"},
+		},
+	)
+
+	opts := Options{AllNamespaces: true, IncludeSystem: true}
+	c := newTestCollector(client, opts)
+
+	builder := graph.NewBuilder()
+	err := c.Collect(context.Background(), builder)
+	if err != nil {
+		t.Fatalf("Collect returned error: %v", err)
+	}
+
+	g := builder.Build()
+
+	systemSA := g.FindNode(graph.NodeServiceAccount, "kube-system", "system-sa")
+	if systemSA == nil {
+		t.Error("expected system namespace SA to be included when IncludeSystem is true")
+	}
+}
+
+func TestKubernetesCollectorImplementsCollector(t *testing.T) {
+	// Compile-time interface check
+	var _ Collector = (*KubernetesCollector)(nil)
+}
+
+func TestCollectClusterRoleBindings(t *testing.T) {
+	client := fake.NewSimpleClientset(
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "admin-binding"},
+			RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "cluster-admin"},
+			Subjects: []rbacv1.Subject{
+				{Kind: "User", Name: "admin-user"},
+			},
+		},
+	)
+	opts := Options{}
+	c := newTestCollector(client, opts)
+
+	builder := graph.NewBuilder()
+
+	// Pre-add the ClusterRole so the edge target exists
+	_ = builder.AddClusterRole(&rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-admin"},
+		Rules:      []rbacv1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"}}},
+	})
+
+	err := c.collectClusterRoleBindings(context.Background(), builder)
+	if err != nil {
+		t.Fatalf("collectClusterRoleBindings returned error: %v", err)
+	}
+
+	g := builder.Build()
+
+	// The User node should have been created
+	userNode := g.FindNode(graph.NodeUser, "", "admin-user")
+	if userNode == nil {
+		t.Error("expected to find admin-user node")
+	}
+
+	// Check edge from user to cluster role
+	if userNode != nil {
+		edges := g.GetOutEdges(userNode.ID)
+		foundBind := false
+		for _, e := range edges {
+			if e.Type == graph.EdgeBinds && e.Metadata.IsClusterBinding {
+				foundBind = true
+			}
+		}
+		if !foundBind {
+			t.Error("expected a cluster binds edge from admin-user")
+		}
+	}
+}

--- a/pkg/collector/openshift_test.go
+++ b/pkg/collector/openshift_test.go
@@ -1,0 +1,321 @@
+package collector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/graph"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var sccGVR = schema.GroupVersionResource{
+	Group:    "security.openshift.io",
+	Version:  "v1",
+	Resource: "securitycontextconstraints",
+}
+
+// newSCCDynamicClient creates a fake dynamic client with the SCC GVR registered
+// and the given unstructured SCC objects pre-loaded via Create calls.
+func newSCCDynamicClient(sccs ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			sccGVR: "SecurityContextConstraintsList",
+		},
+	)
+
+	// The fake dynamic client constructor does not reliably seed unstructured
+	// objects, so we create them explicitly via the tracker.
+	ctx := context.Background()
+	for _, scc := range sccs {
+		_, _ = dynClient.Resource(sccGVR).Create(ctx, scc, metav1.CreateOptions{})
+	}
+
+	return dynClient
+}
+
+func makeSCC(name string, fields map[string]interface{}) *unstructured.Unstructured {
+	obj := map[string]interface{}{
+		"apiVersion": "security.openshift.io/v1",
+		"kind":       "SecurityContextConstraints",
+		"metadata": map[string]interface{}{
+			"name": name,
+		},
+	}
+	for k, v := range fields {
+		obj[k] = v
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func TestOpenShiftCollectorImplementsCollector(t *testing.T) {
+	var _ Collector = (*OpenShiftCollector)(nil)
+}
+
+func TestIsOpenShift_WithSCCs(t *testing.T) {
+	dynClient := newSCCDynamicClient(makeSCC("restricted", nil))
+
+	c := &OpenShiftCollector{
+		client:        fake.NewSimpleClientset(),
+		dynamicClient: dynClient,
+		options:       Options{},
+	}
+
+	if !c.IsOpenShift(context.Background()) {
+		t.Error("expected IsOpenShift to return true when SCCs are present")
+	}
+}
+
+func TestIsOpenShift_EmptyCluster(t *testing.T) {
+	// GVR is registered but no SCC objects exist.
+	dynClient := newSCCDynamicClient()
+
+	c := &OpenShiftCollector{
+		client:        fake.NewSimpleClientset(),
+		dynamicClient: dynClient,
+		options:       Options{},
+	}
+
+	// The SCC API is available (List succeeds with empty result), so IsOpenShift
+	// returns true. This matches real OpenShift behaviour where the API exists
+	// even if no custom SCCs are defined.
+	if !c.IsOpenShift(context.Background()) {
+		t.Error("expected IsOpenShift to return true when SCC API is available")
+	}
+}
+
+func TestOpenShiftCollector_CollectSCCs(t *testing.T) {
+	scc1 := makeSCC("restricted", map[string]interface{}{
+		"allowPrivilegedContainer": false,
+		"allowHostNetwork":         false,
+		"runAsUser": map[string]interface{}{
+			"type": "MustRunAsRange",
+		},
+		"seLinuxContext": map[string]interface{}{
+			"type": "MustRunAs",
+		},
+		"volumes": []interface{}{"configMap", "downwardAPI", "emptyDir", "persistentVolumeClaim", "projected", "secret"},
+	})
+
+	scc2 := makeSCC("privileged", map[string]interface{}{
+		"allowPrivilegedContainer": true,
+		"allowHostNetwork":         true,
+		"allowHostPorts":           true,
+		"allowHostPID":             true,
+		"allowHostIPC":             true,
+		"runAsUser": map[string]interface{}{
+			"type": "RunAsAny",
+		},
+		"seLinuxContext": map[string]interface{}{
+			"type": "RunAsAny",
+		},
+		"volumes":  []interface{}{"*"},
+		"users":    []interface{}{"system:admin"},
+		"groups":   []interface{}{"system:cluster-admins"},
+		"priority": int64(10),
+	})
+
+	dynClient := newSCCDynamicClient(scc1, scc2)
+
+	c := &OpenShiftCollector{
+		client:        fake.NewSimpleClientset(),
+		dynamicClient: dynClient,
+		options:       Options{},
+	}
+
+	builder := graph.NewBuilder()
+	err := c.Collect(context.Background(), builder)
+	if err != nil {
+		t.Fatalf("Collect returned error: %v", err)
+	}
+
+	g := builder.Build()
+	sccNodes := g.GetNodesByType(graph.NodeSCC)
+	if len(sccNodes) != 2 {
+		t.Fatalf("expected 2 SCC nodes, got %d", len(sccNodes))
+	}
+
+	// Verify restricted SCC
+	restricted := g.FindNode(graph.NodeSCC, "", "restricted")
+	if restricted == nil {
+		t.Fatal("expected to find 'restricted' SCC node")
+	}
+	if restricted.Metadata.SCCInfo == nil {
+		t.Fatal("expected SCCInfo to be populated for restricted SCC")
+	}
+	if restricted.Metadata.SCCInfo.AllowPrivilegedContainer {
+		t.Error("restricted SCC should not allow privileged containers")
+	}
+	if restricted.Metadata.SCCInfo.RunAsUserType != "MustRunAsRange" {
+		t.Errorf("expected RunAsUserType 'MustRunAsRange', got %q", restricted.Metadata.SCCInfo.RunAsUserType)
+	}
+
+	// Verify privileged SCC
+	privileged := g.FindNode(graph.NodeSCC, "", "privileged")
+	if privileged == nil {
+		t.Fatal("expected to find 'privileged' SCC node")
+	}
+	if privileged.Metadata.SCCInfo == nil {
+		t.Fatal("expected SCCInfo to be populated for privileged SCC")
+	}
+	if !privileged.Metadata.SCCInfo.AllowPrivilegedContainer {
+		t.Error("privileged SCC should allow privileged containers")
+	}
+	if !privileged.Metadata.SCCInfo.AllowHostNetwork {
+		t.Error("privileged SCC should allow host network")
+	}
+	if !privileged.Metadata.SCCInfo.AllowHostPorts {
+		t.Error("privileged SCC should allow host ports")
+	}
+	if !privileged.Metadata.SCCInfo.AllowHostPID {
+		t.Error("privileged SCC should allow host PID")
+	}
+	if !privileged.Metadata.SCCInfo.AllowHostIPC {
+		t.Error("privileged SCC should allow host IPC")
+	}
+	if privileged.Metadata.SCCInfo.Priority != 10 {
+		t.Errorf("expected priority 10, got %d", privileged.Metadata.SCCInfo.Priority)
+	}
+	if privileged.Metadata.SCCInfo.RunAsUserType != "RunAsAny" {
+		t.Errorf("expected RunAsUserType 'RunAsAny', got %q", privileged.Metadata.SCCInfo.RunAsUserType)
+	}
+	if len(privileged.Metadata.SCCInfo.Users) != 1 || privileged.Metadata.SCCInfo.Users[0] != "system:admin" {
+		t.Errorf("expected users [system:admin], got %v", privileged.Metadata.SCCInfo.Users)
+	}
+	if len(privileged.Metadata.SCCInfo.Groups) != 1 || privileged.Metadata.SCCInfo.Groups[0] != "system:cluster-admins" {
+		t.Errorf("expected groups [system:cluster-admins], got %v", privileged.Metadata.SCCInfo.Groups)
+	}
+}
+
+func TestOpenShiftCollector_CollectSCCs_EmptyList(t *testing.T) {
+	dynClient := newSCCDynamicClient() // GVR registered, no objects
+
+	c := &OpenShiftCollector{
+		client:        fake.NewSimpleClientset(),
+		dynamicClient: dynClient,
+		options:       Options{},
+	}
+
+	builder := graph.NewBuilder()
+	err := c.Collect(context.Background(), builder)
+	if err != nil {
+		t.Fatalf("Collect should not return error with empty SCC list, got: %v", err)
+	}
+
+	g := builder.Build()
+	sccNodes := g.GetNodesByType(graph.NodeSCC)
+	if len(sccNodes) != 0 {
+		t.Errorf("expected 0 SCC nodes with empty list, got %d", len(sccNodes))
+	}
+}
+
+func TestOpenShiftCollector_AddSCC_WithCapabilities(t *testing.T) {
+	scc := makeSCC("custom-scc", map[string]interface{}{
+		"allowedCapabilities":      []interface{}{"NET_ADMIN", "SYS_PTRACE"},
+		"defaultAddCapabilities":   []interface{}{"NET_BIND_SERVICE"},
+		"requiredDropCapabilities": []interface{}{"ALL"},
+		"readOnlyRootFilesystem":   true,
+		"fsGroup": map[string]interface{}{
+			"type": "MustRunAs",
+		},
+		"supplementalGroups": map[string]interface{}{
+			"type": "RunAsAny",
+		},
+	})
+	// Add labels to the SCC metadata
+	scc.Object["metadata"] = map[string]interface{}{
+		"name":   "custom-scc",
+		"labels": map[string]interface{}{"tier": "security"},
+	}
+
+	dynClient := newSCCDynamicClient(scc)
+
+	c := &OpenShiftCollector{
+		client:        fake.NewSimpleClientset(),
+		dynamicClient: dynClient,
+		options:       Options{},
+	}
+
+	builder := graph.NewBuilder()
+	err := c.Collect(context.Background(), builder)
+	if err != nil {
+		t.Fatalf("Collect returned error: %v", err)
+	}
+
+	g := builder.Build()
+	node := g.FindNode(graph.NodeSCC, "", "custom-scc")
+	if node == nil {
+		t.Fatal("expected to find custom-scc node")
+	}
+
+	info := node.Metadata.SCCInfo
+	if info == nil {
+		t.Fatal("expected SCCInfo to be set")
+	}
+
+	if node.Labels == nil || node.Labels["tier"] != "security" {
+		t.Errorf("expected label tier=security, got %v", node.Labels)
+	}
+
+	if len(info.AllowedCapabilities) != 2 {
+		t.Errorf("expected 2 allowed capabilities, got %d", len(info.AllowedCapabilities))
+	}
+	if len(info.DefaultAddCapabilities) != 1 || info.DefaultAddCapabilities[0] != "NET_BIND_SERVICE" {
+		t.Errorf("expected default add cap [NET_BIND_SERVICE], got %v", info.DefaultAddCapabilities)
+	}
+	if len(info.RequiredDropCapabilities) != 1 || info.RequiredDropCapabilities[0] != "ALL" {
+		t.Errorf("expected required drop cap [ALL], got %v", info.RequiredDropCapabilities)
+	}
+	if !info.ReadOnlyRootFilesystem {
+		t.Error("expected ReadOnlyRootFilesystem to be true")
+	}
+	if info.FSGroupType != "MustRunAs" {
+		t.Errorf("expected FSGroupType 'MustRunAs', got %q", info.FSGroupType)
+	}
+	if info.SupplementalGroupsType != "RunAsAny" {
+		t.Errorf("expected SupplementalGroupsType 'RunAsAny', got %q", info.SupplementalGroupsType)
+	}
+}
+
+func TestIsOpenShiftCluster_NoKubeConfig(t *testing.T) {
+	opts := Options{KubeConfigPath: "/nonexistent/kubeconfig"}
+	result := IsOpenShiftCluster(context.Background(), opts)
+	if result {
+		t.Error("expected IsOpenShiftCluster to return false with invalid kubeconfig")
+	}
+}
+
+func TestAddSCC_AllowPrivilegeEscalation(t *testing.T) {
+	scc := makeSCC("no-escalation", map[string]interface{}{
+		"allowPrivilegeEscalation": false,
+	})
+
+	dynClient := newSCCDynamicClient(scc)
+
+	c := &OpenShiftCollector{
+		client:        fake.NewSimpleClientset(),
+		dynamicClient: dynClient,
+		options:       Options{},
+	}
+
+	builder := graph.NewBuilder()
+	_ = c.Collect(context.Background(), builder)
+
+	node := builder.Build().FindNode(graph.NodeSCC, "", "no-escalation")
+	if node == nil {
+		t.Fatal("expected to find no-escalation SCC")
+	}
+	if node.Metadata.SCCInfo.AllowPrivilegeEscalation == nil {
+		t.Fatal("expected AllowPrivilegeEscalation to be set")
+	}
+	if *node.Metadata.SCCInfo.AllowPrivilegeEscalation != false {
+		t.Error("expected AllowPrivilegeEscalation to be false")
+	}
+}

--- a/pkg/graph/graph_test.go
+++ b/pkg/graph/graph_test.go
@@ -1,0 +1,2348 @@
+package graph
+
+import (
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// ---------------------------------------------------------------------------
+// node.go tests
+// ---------------------------------------------------------------------------
+
+func TestNewNode(t *testing.T) {
+	tests := []struct {
+		name      string
+		nodeType  NodeType
+		namespace string
+		nodeName  string
+		wantID    string
+	}{
+		{
+			name:      "namespaced node",
+			nodeType:  NodeServiceAccount,
+			namespace: "default",
+			nodeName:  "my-sa",
+			wantID:    "service_account:default/my-sa",
+		},
+		{
+			name:      "cluster-scoped node",
+			nodeType:  NodeRole,
+			namespace: "",
+			nodeName:  "cluster-admin",
+			wantID:    "role:cluster-admin",
+		},
+		{
+			name:      "workload node",
+			nodeType:  NodeWorkload,
+			namespace: "prod",
+			nodeName:  "api-server",
+			wantID:    "workload:prod/api-server",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NewNode(tt.nodeType, tt.namespace, tt.nodeName)
+			if n.ID != tt.wantID {
+				t.Errorf("ID = %q, want %q", n.ID, tt.wantID)
+			}
+			if n.Type != tt.nodeType {
+				t.Errorf("Type = %q, want %q", n.Type, tt.nodeType)
+			}
+			if n.Namespace != tt.namespace {
+				t.Errorf("Namespace = %q, want %q", n.Namespace, tt.namespace)
+			}
+			if n.Name != tt.nodeName {
+				t.Errorf("Name = %q, want %q", n.Name, tt.nodeName)
+			}
+			if n.Labels == nil {
+				t.Error("Labels map should be initialized")
+			}
+		})
+	}
+}
+
+func TestGenerateNodeID(t *testing.T) {
+	tests := []struct {
+		name      string
+		nodeType  NodeType
+		namespace string
+		nodeName  string
+		want      string
+	}{
+		{"with namespace", NodeServiceAccount, "ns", "sa", "service_account:ns/sa"},
+		{"without namespace", NodeRole, "", "admin", "role:admin"},
+		{"cloud role", NodeCloudRole, "", "arn:aws:iam::123:role/myrole", "cloud_role:arn:aws:iam::123:role/myrole"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateNodeID(tt.nodeType, tt.namespace, tt.nodeName)
+			if got != tt.want {
+				t.Errorf("GenerateNodeID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsClusterScoped(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		want      bool
+	}{
+		{"cluster-scoped", "", true},
+		{"namespaced", "default", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NewNode(NodeRole, tt.namespace, "test")
+			if got := n.IsClusterScoped(); got != tt.want {
+				t.Errorf("IsClusterScoped() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasCloudIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodeType NodeType
+		metadata NodeMetadata
+		want     bool
+	}{
+		{
+			name:     "SA with AWS ARN",
+			nodeType: NodeServiceAccount,
+			metadata: NodeMetadata{CloudRoleARN: "arn:aws:iam::123:role/r"},
+			want:     true,
+		},
+		{
+			name:     "SA with GCP SA",
+			nodeType: NodeServiceAccount,
+			metadata: NodeMetadata{GCPServiceAccount: "sa@proj.iam.gserviceaccount.com"},
+			want:     true,
+		},
+		{
+			name:     "SA with Azure ID",
+			nodeType: NodeServiceAccount,
+			metadata: NodeMetadata{AzureManagedID: "some-client-id"},
+			want:     true,
+		},
+		{
+			name:     "SA without cloud identity",
+			nodeType: NodeServiceAccount,
+			metadata: NodeMetadata{},
+			want:     false,
+		},
+		{
+			name:     "non-SA node with ARN",
+			nodeType: NodeWorkload,
+			metadata: NodeMetadata{CloudRoleARN: "arn:aws:iam::123:role/r"},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NewNode(tt.nodeType, "default", "test")
+			n.Metadata = tt.metadata
+			if got := n.HasCloudIdentity(); got != tt.want {
+				t.Errorf("HasCloudIdentity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// edge.go tests
+// ---------------------------------------------------------------------------
+
+func TestNewEdge(t *testing.T) {
+	e := NewEdge(EdgeBinds, "sa:default/mysa", "role:myrole")
+	wantID := "binds:sa:default/mysa->role:myrole"
+	if e.ID != wantID {
+		t.Errorf("ID = %q, want %q", e.ID, wantID)
+	}
+	if e.Type != EdgeBinds {
+		t.Errorf("Type = %q, want %q", e.Type, EdgeBinds)
+	}
+	if e.From != "sa:default/mysa" {
+		t.Errorf("From = %q", e.From)
+	}
+	if e.To != "role:myrole" {
+		t.Errorf("To = %q", e.To)
+	}
+}
+
+func TestGenerateEdgeID(t *testing.T) {
+	tests := []struct {
+		name     string
+		edgeType EdgeType
+		from, to string
+		want     string
+	}{
+		{"binds", EdgeBinds, "A", "B", "binds:A->B"},
+		{"uses", EdgeUses, "X", "Y", "uses:X->Y"},
+		{"grants", EdgeGrants, "R", "Res", "grants:R->Res"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateEdgeID(tt.edgeType, tt.from, tt.to)
+			if got != tt.want {
+				t.Errorf("GenerateEdgeID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyEdgeSeverity(t *testing.T) {
+	tests := []struct {
+		name       string
+		edge       *Edge
+		targetNode *Node
+		want       Severity
+	}{
+		{
+			name: "grants secrets unscoped -> critical",
+			edge: &Edge{
+				Type:     EdgeGrants,
+				Metadata: EdgeMeta{Verbs: []string{"get", "list"}},
+			},
+			targetNode: &Node{Type: NodeK8sResource, Metadata: NodeMetadata{ResourceKind: "secrets"}},
+			want:       SeverityCritical,
+		},
+		{
+			name: "grants secrets scoped by name -> high",
+			edge: &Edge{
+				Type:     EdgeGrants,
+				Metadata: EdgeMeta{Verbs: []string{"get"}, ResourceNames: []string{"my-secret"}},
+			},
+			targetNode: &Node{Type: NodeK8sResource, Metadata: NodeMetadata{ResourceKind: "secrets"}},
+			want:       SeverityHigh,
+		},
+		{
+			name: "grants pods with dangerous verb unscoped -> high",
+			edge: &Edge{
+				Type:     EdgeGrants,
+				Metadata: EdgeMeta{Verbs: []string{"create"}},
+			},
+			targetNode: &Node{Type: NodeK8sResource, Metadata: NodeMetadata{ResourceKind: "pods"}},
+			want:       SeverityHigh,
+		},
+		{
+			name: "grants pods with dangerous verb scoped -> medium",
+			edge: &Edge{
+				Type:     EdgeGrants,
+				Metadata: EdgeMeta{Verbs: []string{"delete"}, ResourceNames: []string{"my-pod"}},
+			},
+			targetNode: &Node{Type: NodeK8sResource, Metadata: NodeMetadata{ResourceKind: "pods"}},
+			want:       SeverityMedium,
+		},
+		{
+			name: "grants deployments with wildcard verb unscoped -> high",
+			edge: &Edge{
+				Type:     EdgeGrants,
+				Metadata: EdgeMeta{Verbs: []string{"*"}},
+			},
+			targetNode: &Node{Type: NodeK8sResource, Metadata: NodeMetadata{ResourceKind: "deployments"}},
+			want:       SeverityHigh,
+		},
+		{
+			name: "grants configmaps with dangerous verb unscoped -> medium",
+			edge: &Edge{
+				Type:     EdgeGrants,
+				Metadata: EdgeMeta{Verbs: []string{"update"}},
+			},
+			targetNode: &Node{Type: NodeK8sResource, Metadata: NodeMetadata{ResourceKind: "configmaps"}},
+			want:       SeverityMedium,
+		},
+		{
+			name: "grants configmaps with dangerous verb scoped -> low",
+			edge: &Edge{
+				Type:     EdgeGrants,
+				Metadata: EdgeMeta{Verbs: []string{"patch"}, ResourceNames: []string{"cm1"}},
+			},
+			targetNode: &Node{Type: NodeK8sResource, Metadata: NodeMetadata{ResourceKind: "configmaps"}},
+			want:       SeverityLow,
+		},
+		{
+			name: "grants configmaps read-only -> low (default)",
+			edge: &Edge{
+				Type:     EdgeGrants,
+				Metadata: EdgeMeta{Verbs: []string{"get", "list"}},
+			},
+			targetNode: &Node{Type: NodeK8sResource, Metadata: NodeMetadata{ResourceKind: "configmaps"}},
+			want:       SeverityLow,
+		},
+		{
+			name: "grants pods read-only -> low (default)",
+			edge: &Edge{
+				Type:     EdgeGrants,
+				Metadata: EdgeMeta{Verbs: []string{"get"}},
+			},
+			targetNode: &Node{Type: NodeK8sResource, Metadata: NodeMetadata{ResourceKind: "pods"}},
+			want:       SeverityLow,
+		},
+		{
+			name: "grants with nil target -> low",
+			edge: &Edge{
+				Type:     EdgeGrants,
+				Metadata: EdgeMeta{Verbs: []string{"create"}},
+			},
+			targetNode: nil,
+			want:       SeverityLow,
+		},
+		{
+			name: "assumes edge -> high",
+			edge: &Edge{Type: EdgeAssumes},
+			want: SeverityHigh,
+		},
+		{
+			name: "allows edge wildcard -> critical",
+			edge: &Edge{
+				Type:     EdgeAllows,
+				Metadata: EdgeMeta{Actions: []string{"*"}},
+			},
+			want: SeverityCritical,
+		},
+		{
+			name: "allows edge star:star -> critical",
+			edge: &Edge{
+				Type:     EdgeAllows,
+				Metadata: EdgeMeta{Actions: []string{"s3:GetObject", "*:*"}},
+			},
+			want: SeverityCritical,
+		},
+		{
+			name: "allows edge normal -> high",
+			edge: &Edge{
+				Type:     EdgeAllows,
+				Metadata: EdgeMeta{Actions: []string{"s3:GetObject"}},
+			},
+			want: SeverityHigh,
+		},
+		{
+			name: "uses edge -> low",
+			edge: &Edge{Type: EdgeUses},
+			want: SeverityLow,
+		},
+		{
+			name: "binds edge -> low",
+			edge: &Edge{Type: EdgeBinds},
+			want: SeverityLow,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyEdgeSeverity(tt.edge, tt.targetNode)
+			if got != tt.want {
+				t.Errorf("ClassifyEdgeSeverity() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// graph.go tests
+// ---------------------------------------------------------------------------
+
+func TestGraphNew(t *testing.T) {
+	g := New()
+	if g == nil {
+		t.Fatal("New() returned nil")
+	}
+	stats := g.Stats()
+	if stats.TotalNodes != 0 || stats.TotalEdges != 0 {
+		t.Errorf("new graph should be empty, got %d nodes, %d edges", stats.TotalNodes, stats.TotalEdges)
+	}
+}
+
+func TestGraphAddNode(t *testing.T) {
+	g := New()
+	n := NewNode(NodeServiceAccount, "default", "test-sa")
+
+	if err := g.AddNode(n); err != nil {
+		t.Fatalf("AddNode() unexpected error: %v", err)
+	}
+
+	// Verify retrieval
+	got := g.GetNode(n.ID)
+	if got != n {
+		t.Error("GetNode() did not return the added node")
+	}
+
+	// Duplicate should error
+	if err := g.AddNode(n); err == nil {
+		t.Error("AddNode() duplicate should return error")
+	}
+}
+
+func TestGraphAddEdge(t *testing.T) {
+	g := New()
+	n1 := NewNode(NodeWorkload, "default", "dep1")
+	n2 := NewNode(NodeServiceAccount, "default", "sa1")
+	_ = g.AddNode(n1)
+	_ = g.AddNode(n2)
+
+	e := NewEdge(EdgeUses, n1.ID, n2.ID)
+	if err := g.AddEdge(e); err != nil {
+		t.Fatalf("AddEdge() unexpected error: %v", err)
+	}
+
+	// Duplicate edge should silently succeed (no error)
+	if err := g.AddEdge(e); err != nil {
+		t.Errorf("AddEdge() duplicate should return nil, got: %v", err)
+	}
+
+	// Edge with missing source
+	eBadSrc := NewEdge(EdgeUses, "nonexistent", n2.ID)
+	if err := g.AddEdge(eBadSrc); err == nil {
+		t.Error("AddEdge() with missing source should error")
+	}
+
+	// Edge with missing target
+	eBadTgt := NewEdge(EdgeUses, n1.ID, "nonexistent")
+	if err := g.AddEdge(eBadTgt); err == nil {
+		t.Error("AddEdge() with missing target should error")
+	}
+}
+
+func TestGraphGetNodesByType(t *testing.T) {
+	g := New()
+	sa1 := NewNode(NodeServiceAccount, "ns1", "sa1")
+	sa2 := NewNode(NodeServiceAccount, "ns2", "sa2")
+	wl := NewNode(NodeWorkload, "ns1", "dep1")
+	_ = g.AddNode(sa1)
+	_ = g.AddNode(sa2)
+	_ = g.AddNode(wl)
+
+	sas := g.GetNodesByType(NodeServiceAccount)
+	if len(sas) != 2 {
+		t.Errorf("expected 2 SAs, got %d", len(sas))
+	}
+	wls := g.GetNodesByType(NodeWorkload)
+	if len(wls) != 1 {
+		t.Errorf("expected 1 workload, got %d", len(wls))
+	}
+	empty := g.GetNodesByType(NodeCloudRole)
+	if len(empty) != 0 {
+		t.Errorf("expected 0 cloud roles, got %d", len(empty))
+	}
+}
+
+func TestGraphGetNodesByNamespace(t *testing.T) {
+	g := New()
+	_ = g.AddNode(NewNode(NodeServiceAccount, "ns1", "sa1"))
+	_ = g.AddNode(NewNode(NodeWorkload, "ns1", "dep1"))
+	_ = g.AddNode(NewNode(NodeServiceAccount, "ns2", "sa2"))
+	_ = g.AddNode(NewNode(NodeRole, "", "cluster-admin")) // cluster-scoped
+
+	ns1Nodes := g.GetNodesByNamespace("ns1")
+	if len(ns1Nodes) != 2 {
+		t.Errorf("expected 2 nodes in ns1, got %d", len(ns1Nodes))
+	}
+
+	ns2Nodes := g.GetNodesByNamespace("ns2")
+	if len(ns2Nodes) != 1 {
+		t.Errorf("expected 1 node in ns2, got %d", len(ns2Nodes))
+	}
+
+	// Cluster-scoped nodes should not appear in any namespace
+	emptyNS := g.GetNodesByNamespace("")
+	if len(emptyNS) != 0 {
+		t.Errorf("expected 0 nodes for empty namespace, got %d", len(emptyNS))
+	}
+}
+
+func TestGraphOutAndInEdges(t *testing.T) {
+	g := New()
+	n1 := NewNode(NodeWorkload, "ns", "dep")
+	n2 := NewNode(NodeServiceAccount, "ns", "sa")
+	n3 := NewNode(NodeRole, "ns", "role")
+	_ = g.AddNode(n1)
+	_ = g.AddNode(n2)
+	_ = g.AddNode(n3)
+
+	e1 := NewEdge(EdgeUses, n1.ID, n2.ID)
+	e2 := NewEdge(EdgeBinds, n2.ID, n3.ID)
+	_ = g.AddEdge(e1)
+	_ = g.AddEdge(e2)
+
+	outN1 := g.GetOutEdges(n1.ID)
+	if len(outN1) != 1 || outN1[0].To != n2.ID {
+		t.Errorf("GetOutEdges(n1) = %v", outN1)
+	}
+
+	inN2 := g.GetInEdges(n2.ID)
+	if len(inN2) != 1 || inN2[0].From != n1.ID {
+		t.Errorf("GetInEdges(n2) = %v", inN2)
+	}
+
+	outN2 := g.GetOutEdges(n2.ID)
+	if len(outN2) != 1 || outN2[0].To != n3.ID {
+		t.Errorf("GetOutEdges(n2) = %v", outN2)
+	}
+
+	inN3 := g.GetInEdges(n3.ID)
+	if len(inN3) != 1 || inN3[0].From != n2.ID {
+		t.Errorf("GetInEdges(n3) = %v", inN3)
+	}
+}
+
+func TestGraphFindNode(t *testing.T) {
+	g := New()
+	n := NewNode(NodeServiceAccount, "default", "my-sa")
+	_ = g.AddNode(n)
+
+	found := g.FindNode(NodeServiceAccount, "default", "my-sa")
+	if found != n {
+		t.Error("FindNode() did not return expected node")
+	}
+
+	missing := g.FindNode(NodeServiceAccount, "default", "other-sa")
+	if missing != nil {
+		t.Error("FindNode() should return nil for missing node")
+	}
+}
+
+func TestGraphStats(t *testing.T) {
+	g := New()
+	sa := NewNode(NodeServiceAccount, "ns", "sa")
+	wl := NewNode(NodeWorkload, "ns", "dep")
+	role := NewNode(NodeRole, "", "admin")
+	_ = g.AddNode(sa)
+	_ = g.AddNode(wl)
+	_ = g.AddNode(role)
+
+	e1 := NewEdge(EdgeUses, wl.ID, sa.ID)
+	e2 := NewEdge(EdgeBinds, sa.ID, role.ID)
+	_ = g.AddEdge(e1)
+	_ = g.AddEdge(e2)
+
+	stats := g.Stats()
+	if stats.TotalNodes != 3 {
+		t.Errorf("TotalNodes = %d, want 3", stats.TotalNodes)
+	}
+	if stats.TotalEdges != 2 {
+		t.Errorf("TotalEdges = %d, want 2", stats.TotalEdges)
+	}
+	if stats.NodeCounts[NodeServiceAccount] != 1 {
+		t.Errorf("SA count = %d, want 1", stats.NodeCounts[NodeServiceAccount])
+	}
+	if stats.EdgeCounts[EdgeUses] != 1 {
+		t.Errorf("Uses edge count = %d, want 1", stats.EdgeCounts[EdgeUses])
+	}
+}
+
+func TestGraphAllNodesAndEdges(t *testing.T) {
+	g := New()
+	n1 := NewNode(NodeServiceAccount, "ns", "sa")
+	n2 := NewNode(NodeWorkload, "ns", "dep")
+	_ = g.AddNode(n1)
+	_ = g.AddNode(n2)
+
+	e := NewEdge(EdgeUses, n2.ID, n1.ID)
+	_ = g.AddEdge(e)
+
+	allNodes := g.AllNodes()
+	if len(allNodes) != 2 {
+		t.Errorf("AllNodes() len = %d, want 2", len(allNodes))
+	}
+
+	allEdges := g.AllEdges()
+	if len(allEdges) != 1 {
+		t.Errorf("AllEdges() len = %d, want 1", len(allEdges))
+	}
+}
+
+func TestGraphGetWorkloadsUsingSA(t *testing.T) {
+	g := New()
+	sa := NewNode(NodeServiceAccount, "ns", "sa")
+	dep1 := NewNode(NodeWorkload, "ns", "dep1")
+	dep2 := NewNode(NodeWorkload, "ns", "dep2")
+	_ = g.AddNode(sa)
+	_ = g.AddNode(dep1)
+	_ = g.AddNode(dep2)
+
+	_ = g.AddEdge(NewEdge(EdgeUses, dep1.ID, sa.ID))
+	_ = g.AddEdge(NewEdge(EdgeUses, dep2.ID, sa.ID))
+
+	workloads := g.GetWorkloadsUsingSA(sa.ID)
+	if len(workloads) != 2 {
+		t.Errorf("GetWorkloadsUsingSA() returned %d workloads, want 2", len(workloads))
+	}
+
+	// Non-EdgeUses edges should not be tracked
+	role := NewNode(NodeRole, "", "r")
+	_ = g.AddNode(role)
+	_ = g.AddEdge(NewEdge(EdgeBinds, sa.ID, role.ID))
+
+	workloads = g.GetWorkloadsUsingSA(sa.ID)
+	if len(workloads) != 2 {
+		t.Errorf("After adding binds edge, GetWorkloadsUsingSA() returned %d, want 2", len(workloads))
+	}
+
+	// Unknown SA returns nil/empty
+	unknown := g.GetWorkloadsUsingSA("nonexistent")
+	if len(unknown) != 0 {
+		t.Errorf("expected 0, got %d", len(unknown))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// builder.go tests
+// ---------------------------------------------------------------------------
+
+func TestNewBuilderAndBuild(t *testing.T) {
+	b := NewBuilder()
+	if b == nil {
+		t.Fatal("NewBuilder() returned nil")
+	}
+	g := b.Build()
+	if g == nil {
+		t.Fatal("Build() returned nil")
+	}
+	// Graph() is an alias
+	if b.Graph() != g {
+		t.Error("Graph() and Build() should return the same instance")
+	}
+}
+
+func TestBuilderAddServiceAccount(t *testing.T) {
+	tests := []struct {
+		name            string
+		sa              *corev1.ServiceAccount
+		wantCloudARN    string
+		wantGCPSA       string
+		wantAzureID     string
+		wantAutomount   bool
+		wantEKSPodIdent string
+	}{
+		{
+			name: "basic SA",
+			sa: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sa",
+					Namespace: "default",
+				},
+			},
+			wantAutomount: true, // default when nil
+		},
+		{
+			name: "SA with AWS annotation",
+			sa: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "aws-sa",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"eks.amazonaws.com/role-arn": "arn:aws:iam::123:role/myrole",
+					},
+				},
+			},
+			wantCloudARN:  "arn:aws:iam::123:role/myrole",
+			wantAutomount: true,
+		},
+		{
+			name: "SA with GCP annotation",
+			sa: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gcp-sa",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"iam.gke.io/gcp-service-account": "sa@proj.iam.gserviceaccount.com",
+					},
+				},
+			},
+			wantGCPSA:     "sa@proj.iam.gserviceaccount.com",
+			wantAutomount: true,
+		},
+		{
+			name: "SA with Azure annotation",
+			sa: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "azure-sa",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"azure.workload.identity/client-id": "client-id-123",
+					},
+				},
+			},
+			wantAzureID:   "client-id-123",
+			wantAutomount: true,
+		},
+		{
+			name: "SA with automount disabled",
+			sa: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-mount-sa",
+					Namespace: "default",
+				},
+				AutomountServiceAccountToken: boolPtr(false),
+			},
+			wantAutomount: false,
+		},
+		{
+			name: "SA with EKS Pod Identity annotation",
+			sa: &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "eks-pi-sa",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"pods.eks.amazonaws.com/service-account-token-audience": "sts.amazonaws.com",
+					},
+				},
+			},
+			wantEKSPodIdent: "sts.amazonaws.com",
+			wantAutomount:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBuilder()
+			if err := b.AddServiceAccount(tt.sa); err != nil {
+				t.Fatalf("AddServiceAccount() error: %v", err)
+			}
+
+			node := b.graph.FindNode(NodeServiceAccount, tt.sa.Namespace, tt.sa.Name)
+			if node == nil {
+				t.Fatal("SA node not found")
+			}
+			if node.Metadata.CloudRoleARN != tt.wantCloudARN {
+				t.Errorf("CloudRoleARN = %q, want %q", node.Metadata.CloudRoleARN, tt.wantCloudARN)
+			}
+			if node.Metadata.GCPServiceAccount != tt.wantGCPSA {
+				t.Errorf("GCPServiceAccount = %q, want %q", node.Metadata.GCPServiceAccount, tt.wantGCPSA)
+			}
+			if node.Metadata.AzureManagedID != tt.wantAzureID {
+				t.Errorf("AzureManagedID = %q, want %q", node.Metadata.AzureManagedID, tt.wantAzureID)
+			}
+			if node.Metadata.AutomountToken != tt.wantAutomount {
+				t.Errorf("AutomountToken = %v, want %v", node.Metadata.AutomountToken, tt.wantAutomount)
+			}
+			if node.Metadata.EKSPodIdentityAssociation != tt.wantEKSPodIdent {
+				t.Errorf("EKSPodIdentityAssociation = %q, want %q", node.Metadata.EKSPodIdentityAssociation, tt.wantEKSPodIdent)
+			}
+
+			// If EKS Pod Identity is set, check that an assumes edge and cloud_role node were created
+			if tt.wantEKSPodIdent != "" {
+				cloudRoleID := GenerateNodeID(NodeCloudRole, "", tt.wantEKSPodIdent)
+				cr := b.graph.GetNode(cloudRoleID)
+				if cr == nil {
+					t.Error("expected cloud role node for EKS Pod Identity")
+				}
+				edges := b.graph.GetOutEdges(node.ID)
+				foundAssumes := false
+				for _, e := range edges {
+					if e.Type == EdgeAssumes && e.To == cloudRoleID {
+						foundAssumes = true
+					}
+				}
+				if !foundAssumes {
+					t.Error("expected EdgeAssumes from SA to cloud role")
+				}
+			}
+		})
+	}
+}
+
+func TestBuilderAddRole(t *testing.T) {
+	b := NewBuilder()
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-reader",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test"},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"get", "list"},
+			},
+		},
+	}
+
+	if err := b.AddRole(role); err != nil {
+		t.Fatalf("AddRole() error: %v", err)
+	}
+
+	node := b.graph.FindNode(NodeRole, "default", "pod-reader")
+	if node == nil {
+		t.Fatal("role node not found")
+	}
+	if node.Metadata.IsClusterRole {
+		t.Error("IsClusterRole should be false for Role")
+	}
+	if len(node.Metadata.Rules) != 1 {
+		t.Errorf("expected 1 rule, got %d", len(node.Metadata.Rules))
+	}
+	if node.Labels["app"] != "test" {
+		t.Error("labels not set correctly")
+	}
+}
+
+func TestBuilderAddClusterRole(t *testing.T) {
+	b := NewBuilder()
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster-admin",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"*"},
+				Resources: []string{"*"},
+				Verbs:     []string{"*"},
+			},
+		},
+	}
+
+	if err := b.AddClusterRole(cr); err != nil {
+		t.Fatalf("AddClusterRole() error: %v", err)
+	}
+
+	node := b.graph.FindNode(NodeRole, "", "cluster-admin")
+	if node == nil {
+		t.Fatal("cluster role node not found")
+	}
+	if !node.Metadata.IsClusterRole {
+		t.Error("IsClusterRole should be true for ClusterRole")
+	}
+	if node.Metadata.IsAggregated {
+		t.Error("non-aggregated ClusterRole should not be marked aggregated")
+	}
+}
+
+func TestBuilderAddClusterRoleAggregated(t *testing.T) {
+	b := NewBuilder()
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "aggregated-role",
+		},
+		AggregationRule: &rbacv1.AggregationRule{
+			ClusterRoleSelectors: []metav1.LabelSelector{
+				{MatchLabels: map[string]string{"rbac.example.com/aggregate-to-admin": "true"}},
+			},
+		},
+	}
+
+	if err := b.AddClusterRole(cr); err != nil {
+		t.Fatalf("AddClusterRole() error: %v", err)
+	}
+
+	node := b.graph.FindNode(NodeRole, "", "aggregated-role")
+	if node == nil {
+		t.Fatal("aggregated cluster role node not found")
+	}
+	if !node.Metadata.IsAggregated {
+		t.Error("IsAggregated should be true")
+	}
+}
+
+func TestBuilderAddRoleBinding(t *testing.T) {
+	b := NewBuilder()
+	// Pre-create the SA and Role nodes
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-sa", Namespace: "default"},
+	}
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-role", Namespace: "default"},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}},
+		},
+	}
+	_ = b.AddServiceAccount(sa)
+	_ = b.AddRole(role)
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-binding",
+			Namespace: "default",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "Role",
+			Name: "my-role",
+		},
+		Subjects: []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: "my-sa", Namespace: "default"},
+		},
+	}
+
+	if err := b.AddRoleBinding(rb); err != nil {
+		t.Fatalf("AddRoleBinding() error: %v", err)
+	}
+
+	saNodeID := GenerateNodeID(NodeServiceAccount, "default", "my-sa")
+	roleNodeID := GenerateNodeID(NodeRole, "default", "my-role")
+
+	edges := b.graph.GetOutEdges(saNodeID)
+	found := false
+	for _, e := range edges {
+		if e.Type == EdgeBinds && e.To == roleNodeID {
+			found = true
+			if e.Metadata.BindingName != "my-binding" {
+				t.Errorf("BindingName = %q, want %q", e.Metadata.BindingName, "my-binding")
+			}
+			if e.Metadata.IsClusterBinding {
+				t.Error("IsClusterBinding should be false for RoleBinding")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected EdgeBinds from SA to Role")
+	}
+}
+
+func TestBuilderAddRoleBindingClusterRole(t *testing.T) {
+	b := NewBuilder()
+	// RoleBinding referencing a ClusterRole
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-sa", Namespace: "default"},
+	}
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "view"},
+		Rules:      []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}}},
+	}
+	_ = b.AddServiceAccount(sa)
+	_ = b.AddClusterRole(cr)
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "view-binding", Namespace: "default"},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "view"},
+		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: "my-sa", Namespace: "default"}},
+	}
+	_ = b.AddRoleBinding(rb)
+
+	// The role node ID should be cluster-scoped (no namespace) for ClusterRole
+	roleNodeID := GenerateNodeID(NodeRole, "", "view")
+	saNodeID := GenerateNodeID(NodeServiceAccount, "default", "my-sa")
+
+	edges := b.graph.GetOutEdges(saNodeID)
+	found := false
+	for _, e := range edges {
+		if e.Type == EdgeBinds && e.To == roleNodeID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected EdgeBinds from SA to ClusterRole")
+	}
+}
+
+func TestBuilderAddRoleBindingUserAndGroup(t *testing.T) {
+	b := NewBuilder()
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns"},
+		Rules:      []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}}},
+	}
+	_ = b.AddRole(role)
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: "ns"},
+		RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "r"},
+		Subjects: []rbacv1.Subject{
+			{Kind: "User", Name: "alice"},
+			{Kind: "Group", Name: "developers"},
+			{Kind: "InvalidKind", Name: "skip"}, // should be skipped
+		},
+	}
+	_ = b.AddRoleBinding(rb)
+
+	// User node should have been created
+	userNode := b.graph.FindNode(NodeUser, "", "alice")
+	if userNode == nil {
+		t.Error("expected User node for alice")
+	}
+
+	// Group node should have been created
+	groupNode := b.graph.FindNode(NodeGroup, "", "developers")
+	if groupNode == nil {
+		t.Error("expected Group node for developers")
+	}
+}
+
+func TestBuilderAddClusterRoleBinding(t *testing.T) {
+	b := NewBuilder()
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "admin-sa", Namespace: "kube-system"},
+	}
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-admin"},
+		Rules:      []rbacv1.PolicyRule{{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"*"}}},
+	}
+	_ = b.AddServiceAccount(sa)
+	_ = b.AddClusterRole(cr)
+
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "admin-binding"},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "cluster-admin"},
+		Subjects: []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: "admin-sa", Namespace: "kube-system"},
+			{Kind: "User", Name: "admin-user"},
+			{Kind: "Group", Name: "admins"},
+		},
+	}
+
+	if err := b.AddClusterRoleBinding(crb); err != nil {
+		t.Fatalf("AddClusterRoleBinding() error: %v", err)
+	}
+
+	saNodeID := GenerateNodeID(NodeServiceAccount, "kube-system", "admin-sa")
+	roleNodeID := GenerateNodeID(NodeRole, "", "cluster-admin")
+
+	edges := b.graph.GetOutEdges(saNodeID)
+	found := false
+	for _, e := range edges {
+		if e.Type == EdgeBinds && e.To == roleNodeID {
+			found = true
+			if !e.Metadata.IsClusterBinding {
+				t.Error("IsClusterBinding should be true for ClusterRoleBinding")
+			}
+			if e.Metadata.BindingName != "admin-binding" {
+				t.Errorf("BindingName = %q", e.Metadata.BindingName)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected EdgeBinds from SA to cluster role")
+	}
+
+	// Check User and Group were created
+	if b.graph.FindNode(NodeUser, "", "admin-user") == nil {
+		t.Error("expected User node")
+	}
+	if b.graph.FindNode(NodeGroup, "", "admins") == nil {
+		t.Error("expected Group node")
+	}
+}
+
+func TestBuilderAddDeployment(t *testing.T) {
+	b := NewBuilder()
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "app-sa", Namespace: "prod"},
+	}
+	_ = b.AddServiceAccount(sa)
+
+	replicas := int32(3)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app",
+			Namespace: "prod",
+			Labels:    map[string]string{"app": "myapp"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "app-sa",
+					Containers: []corev1.Container{
+						{Name: "main", Image: "nginx"},
+					},
+				},
+			},
+		},
+	}
+
+	if err := b.AddDeployment(dep); err != nil {
+		t.Fatalf("AddDeployment() error: %v", err)
+	}
+
+	node := b.graph.FindNode(NodeWorkload, "prod", "app")
+	if node == nil {
+		t.Fatal("deployment node not found")
+	}
+	if node.Metadata.WorkloadKind != "Deployment" {
+		t.Errorf("WorkloadKind = %q", node.Metadata.WorkloadKind)
+	}
+	if node.Metadata.Replicas != 3 {
+		t.Errorf("Replicas = %d, want 3", node.Metadata.Replicas)
+	}
+	if node.Labels["app"] != "myapp" {
+		t.Error("labels not set")
+	}
+
+	// Check EdgeUses to SA
+	saNodeID := GenerateNodeID(NodeServiceAccount, "prod", "app-sa")
+	edges := b.graph.GetOutEdges(node.ID)
+	found := false
+	for _, e := range edges {
+		if e.Type == EdgeUses && e.To == saNodeID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected EdgeUses from deployment to SA")
+	}
+}
+
+func TestBuilderAddDeploymentDefaultSA(t *testing.T) {
+	b := NewBuilder()
+	// Pre-create the default SA
+	_ = b.AddServiceAccount(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"},
+	})
+
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "dep", Namespace: "ns"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					// ServiceAccountName not set -> should default to "default"
+					Containers: []corev1.Container{{Name: "c", Image: "img"}},
+				},
+			},
+		},
+	}
+
+	if err := b.AddDeployment(dep); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	saNodeID := GenerateNodeID(NodeServiceAccount, "ns", "default")
+	wlNodeID := GenerateNodeID(NodeWorkload, "ns", "dep")
+	edges := b.graph.GetOutEdges(wlNodeID)
+	found := false
+	for _, e := range edges {
+		if e.Type == EdgeUses && e.To == saNodeID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("deployment with no SA specified should use 'default'")
+	}
+}
+
+func TestBuilderBuildResourceEdges(t *testing.T) {
+	b := NewBuilder()
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-reader", Namespace: "default"},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods", "pods/log"},
+				Verbs:     []string{"get", "list"},
+			},
+		},
+	}
+	_ = b.AddRole(role)
+
+	b.BuildResourceEdges()
+
+	roleNodeID := GenerateNodeID(NodeRole, "default", "pod-reader")
+	edges := b.graph.GetOutEdges(roleNodeID)
+	if len(edges) != 2 {
+		t.Fatalf("expected 2 resource edges, got %d", len(edges))
+	}
+
+	for _, e := range edges {
+		if e.Type != EdgeGrants {
+			t.Errorf("edge type = %q, want %q", e.Type, EdgeGrants)
+		}
+		if len(e.Metadata.Verbs) != 2 {
+			t.Errorf("edge verbs = %v", e.Metadata.Verbs)
+		}
+	}
+
+	// Check resource nodes created
+	podsNode := b.graph.FindNode(NodeK8sResource, "default", "pods")
+	if podsNode == nil {
+		t.Error("pods resource node not created")
+	} else if podsNode.Metadata.ResourceKind != "pods" {
+		t.Errorf("ResourceKind = %q", podsNode.Metadata.ResourceKind)
+	}
+}
+
+func TestBuilderBuildResourceEdgesIdempotent(t *testing.T) {
+	b := NewBuilder()
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns"},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{""}, Resources: []string{"secrets"}, Verbs: []string{"get"}},
+		},
+	}
+	_ = b.AddRole(role)
+
+	b.BuildResourceEdges()
+	b.BuildResourceEdges() // second call should be idempotent (duplicate edges silently succeed)
+
+	roleNodeID := GenerateNodeID(NodeRole, "ns", "r")
+	edges := b.graph.GetOutEdges(roleNodeID)
+	if len(edges) != 1 {
+		t.Errorf("expected 1 edge after double BuildResourceEdges, got %d", len(edges))
+	}
+}
+
+func TestBuilderAddNetworkPolicy(t *testing.T) {
+	b := NewBuilder()
+	protocol := corev1.ProtocolTCP
+	port := intstr.FromInt32(80)
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deny-all",
+			Namespace: "default",
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "web"},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"role": "frontend"},
+							},
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &protocol, Port: &port},
+					},
+				},
+			},
+		},
+	}
+
+	if err := b.AddNetworkPolicy(np); err != nil {
+		t.Fatalf("AddNetworkPolicy() error: %v", err)
+	}
+
+	node := b.graph.FindNode(NodeNetworkPolicy, "default", "deny-all")
+	if node == nil {
+		t.Fatal("network policy node not found")
+	}
+	if node.Metadata.NetworkPolicy == nil {
+		t.Fatal("NetworkPolicy metadata nil")
+	}
+	npInfo := node.Metadata.NetworkPolicy
+	if npInfo.PodSelector["app"] != "web" {
+		t.Error("PodSelector not set")
+	}
+	if len(npInfo.PolicyTypes) != 2 {
+		t.Errorf("PolicyTypes len = %d", len(npInfo.PolicyTypes))
+	}
+	if len(npInfo.IngressRules) != 1 {
+		t.Errorf("IngressRules len = %d", len(npInfo.IngressRules))
+	}
+	if npInfo.IngressRules[0].FromPodSelector["role"] != "frontend" {
+		t.Error("ingress FromPodSelector not set")
+	}
+	if len(npInfo.IngressRules[0].Ports) != 1 {
+		t.Error("ingress ports not set")
+	}
+	// Egress is in policy types but no rules -> deny all
+	if !npInfo.DenyAllEgress {
+		t.Error("expected DenyAllEgress=true when Egress policy type present but no rules")
+	}
+}
+
+func TestBuilderAddNetworkPolicyDenyAllIngress(t *testing.T) {
+	b := NewBuilder()
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "deny-ingress", Namespace: "ns"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			// No Ingress rules -> deny all
+		},
+	}
+	_ = b.AddNetworkPolicy(np)
+
+	node := b.graph.FindNode(NodeNetworkPolicy, "ns", "deny-ingress")
+	if node == nil || node.Metadata.NetworkPolicy == nil {
+		t.Fatal("node or metadata nil")
+	}
+	if !node.Metadata.NetworkPolicy.DenyAllIngress {
+		t.Error("expected DenyAllIngress=true")
+	}
+}
+
+func TestBuilderAddNetworkPolicyAllowAllIngress(t *testing.T) {
+	b := NewBuilder()
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "allow-all", Namespace: "ns"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{}, // empty from + empty ports = allow all
+			},
+		},
+	}
+	_ = b.AddNetworkPolicy(np)
+
+	node := b.graph.FindNode(NodeNetworkPolicy, "ns", "allow-all")
+	if !node.Metadata.NetworkPolicy.AllowAllIngress {
+		t.Error("expected AllowAllIngress=true")
+	}
+}
+
+func TestBuilderAddService(t *testing.T) {
+	b := NewBuilder()
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-svc",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "web"},
+		},
+		Spec: corev1.ServiceSpec{
+			Type:      corev1.ServiceTypeLoadBalancer,
+			ClusterIP: "10.0.0.1",
+			Selector:  map[string]string{"app": "web"},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromInt32(8080),
+					NodePort:   30080,
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+
+	if err := b.AddService(svc); err != nil {
+		t.Fatalf("AddService() error: %v", err)
+	}
+
+	node := b.graph.FindNode(NodeService, "default", "my-svc")
+	if node == nil {
+		t.Fatal("service node not found")
+	}
+	si := node.Metadata.ServiceInfo
+	if si == nil {
+		t.Fatal("ServiceInfo nil")
+	}
+	if si.ServiceType != "LoadBalancer" {
+		t.Errorf("ServiceType = %q", si.ServiceType)
+	}
+	if si.ClusterIP != "10.0.0.1" {
+		t.Errorf("ClusterIP = %q", si.ClusterIP)
+	}
+	if len(si.Ports) != 1 {
+		t.Fatalf("Ports len = %d", len(si.Ports))
+	}
+	if si.Ports[0].Port != 80 || si.Ports[0].NodePort != 30080 {
+		t.Errorf("Port = %d, NodePort = %d", si.Ports[0].Port, si.Ports[0].NodePort)
+	}
+}
+
+func TestParseWorkloadRef(t *testing.T) {
+	tests := []struct {
+		ref          string
+		defaultNS    string
+		wantKind     string
+		wantNS       string
+		wantName     string
+	}{
+		// single-part: default to Deployment
+		{"myapp", "default", "Deployment", "default", "myapp"},
+		// kind/name variants
+		{"deployment/myapp", "default", "Deployment", "default", "myapp"},
+		{"deploy/myapp", "default", "Deployment", "default", "myapp"},
+		{"deployments/myapp", "default", "Deployment", "default", "myapp"},
+		{"statefulset/mydb", "ns", "StatefulSet", "ns", "mydb"},
+		{"sts/mydb", "ns", "StatefulSet", "ns", "mydb"},
+		{"statefulsets/mydb", "ns", "StatefulSet", "ns", "mydb"},
+		{"daemonset/agent", "ns", "DaemonSet", "ns", "agent"},
+		{"ds/agent", "ns", "DaemonSet", "ns", "agent"},
+		{"daemonsets/agent", "ns", "DaemonSet", "ns", "agent"},
+		{"job/myjob", "ns", "Job", "ns", "myjob"},
+		{"jobs/myjob", "ns", "Job", "ns", "myjob"},
+		{"cronjob/cj", "ns", "CronJob", "ns", "cj"},
+		{"cj/cj", "ns", "CronJob", "ns", "cj"},
+		{"cronjobs/cj", "ns", "CronJob", "ns", "cj"},
+		{"pod/mypod", "ns", "Pod", "ns", "mypod"},
+		{"pods/mypod", "ns", "Pod", "ns", "mypod"},
+		// 2-part with unknown kind prefix -> treated as namespace/name
+		{"mynamespace/myapp", "default", "Deployment", "mynamespace", "myapp"},
+		// 3-part: kind/namespace/name
+		{"StatefulSet/prod/mydb", "default", "StatefulSet", "prod", "mydb"},
+		// 4+ parts: fallback
+		{"a/b/c/d", "default", "Deployment", "default", "a/b/c/d"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			kind, ns, name := ParseWorkloadRef(tt.ref, tt.defaultNS)
+			if kind != tt.wantKind {
+				t.Errorf("kind = %q, want %q", kind, tt.wantKind)
+			}
+			if ns != tt.wantNS {
+				t.Errorf("namespace = %q, want %q", ns, tt.wantNS)
+			}
+			if name != tt.wantName {
+				t.Errorf("name = %q, want %q", name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestBuilderAddCloudRoleEdge(t *testing.T) {
+	b := NewBuilder()
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: "ns"},
+	}
+	_ = b.AddServiceAccount(sa)
+
+	err := b.AddCloudRoleEdge("ns", "sa", "aws", "arn:aws:iam::123:role/r")
+	if err != nil {
+		t.Fatalf("AddCloudRoleEdge() error: %v", err)
+	}
+
+	// Cloud role node should exist
+	cloudID := GenerateNodeID(NodeCloudRole, "", "arn:aws:iam::123:role/r")
+	cr := b.graph.GetNode(cloudID)
+	if cr == nil {
+		t.Fatal("cloud role node not created")
+	}
+	if cr.Metadata.CloudProvider != "aws" {
+		t.Errorf("CloudProvider = %q", cr.Metadata.CloudProvider)
+	}
+
+	// Edge should exist
+	saID := GenerateNodeID(NodeServiceAccount, "ns", "sa")
+	edges := b.graph.GetOutEdges(saID)
+	found := false
+	for _, e := range edges {
+		if e.Type == EdgeAssumes && e.To == cloudID {
+			found = true
+			if e.Metadata.RoleARN != "arn:aws:iam::123:role/r" {
+				t.Errorf("RoleARN = %q", e.Metadata.RoleARN)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected EdgeAssumes from SA to cloud role")
+	}
+
+	// Calling again should reuse existing cloud role node
+	err = b.AddCloudRoleEdge("ns", "sa", "aws", "arn:aws:iam::123:role/r")
+	if err != nil {
+		t.Errorf("second AddCloudRoleEdge() error: %v", err)
+	}
+	cloudRoles := b.graph.GetNodesByType(NodeCloudRole)
+	if len(cloudRoles) != 1 {
+		t.Errorf("expected 1 cloud role node, got %d", len(cloudRoles))
+	}
+}
+
+func TestBuilderGetWorkloadNetworkExposure(t *testing.T) {
+	b := NewBuilder()
+
+	// Create a workload
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: "ns"}}
+	_ = b.AddServiceAccount(sa)
+
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web",
+			Namespace: "ns",
+			Labels:    map[string]string{"app": "web"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "sa",
+					Containers:         []corev1.Container{{Name: "c", Image: "img"}},
+				},
+			},
+		},
+	}
+	_ = b.AddDeployment(dep)
+
+	// Add a network policy that selects this workload
+	protocol := corev1.ProtocolTCP
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "np", Namespace: "ns"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					From: []networkingv1.NetworkPolicyPeer{
+						{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "frontend"}}},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &protocol, Port: ptrIntStr(intstr.FromInt32(80))},
+					},
+				},
+			},
+		},
+	}
+	_ = b.AddNetworkPolicy(np)
+
+	// Add a LoadBalancer service that selects this workload
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-svc", Namespace: "ns"},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeLoadBalancer,
+			Selector: map[string]string{"app": "web"},
+			Ports: []corev1.ServicePort{
+				{Port: 80, Protocol: corev1.ProtocolTCP},
+			},
+		},
+	}
+	_ = b.AddService(svc)
+
+	wlID := GenerateNodeID(NodeWorkload, "ns", "web")
+	exposure := b.GetWorkloadNetworkExposure(wlID)
+	if exposure == nil {
+		t.Fatal("GetWorkloadNetworkExposure() returned nil")
+	}
+	if exposure.WorkloadName != "web" {
+		t.Errorf("WorkloadName = %q", exposure.WorkloadName)
+	}
+	if len(exposure.NetworkPolicies) != 1 || exposure.NetworkPolicies[0] != "np" {
+		t.Errorf("NetworkPolicies = %v", exposure.NetworkPolicies)
+	}
+	if !exposure.HasIngressPolicy {
+		t.Error("expected HasIngressPolicy=true")
+	}
+	if len(exposure.Services) != 1 || exposure.Services[0].Name != "web-svc" {
+		t.Errorf("Services = %v", exposure.Services)
+	}
+	if !exposure.IsExternallyExposed {
+		t.Error("expected IsExternallyExposed=true for LoadBalancer")
+	}
+
+	// Non-existent workload
+	if got := b.GetWorkloadNetworkExposure("nonexistent"); got != nil {
+		t.Error("expected nil for nonexistent workload")
+	}
+}
+
+func TestBuilderGetWorkloadNetworkExposureNoMatch(t *testing.T) {
+	b := NewBuilder()
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: "ns"}}
+	_ = b.AddServiceAccount(sa)
+
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend",
+			Namespace: "ns",
+			Labels:    map[string]string{"app": "backend"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "sa",
+					Containers:         []corev1.Container{{Name: "c", Image: "img"}},
+				},
+			},
+		},
+	}
+	_ = b.AddDeployment(dep)
+
+	// NP in same namespace but selects different labels
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "np", Namespace: "ns"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		},
+	}
+	_ = b.AddNetworkPolicy(np)
+
+	// Service in different namespace
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "other-ns"},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": "backend"},
+			Ports:    []corev1.ServicePort{{Port: 80}},
+		},
+	}
+	_ = b.AddService(svc)
+
+	wlID := GenerateNodeID(NodeWorkload, "ns", "backend")
+	exposure := b.GetWorkloadNetworkExposure(wlID)
+	if len(exposure.NetworkPolicies) != 0 {
+		t.Errorf("expected no network policies, got %v", exposure.NetworkPolicies)
+	}
+	if len(exposure.Services) != 0 {
+		t.Errorf("expected no services, got %v", exposure.Services)
+	}
+}
+
+func TestMatchLabels(t *testing.T) {
+	tests := []struct {
+		name      string
+		workload  map[string]string
+		selector  map[string]string
+		want      bool
+	}{
+		{"empty selector matches all", map[string]string{"a": "1"}, nil, true},
+		{"exact match", map[string]string{"a": "1"}, map[string]string{"a": "1"}, true},
+		{"subset match", map[string]string{"a": "1", "b": "2"}, map[string]string{"a": "1"}, true},
+		{"mismatch value", map[string]string{"a": "1"}, map[string]string{"a": "2"}, false},
+		{"missing key", map[string]string{"a": "1"}, map[string]string{"b": "1"}, false},
+		{"workload has no labels", nil, map[string]string{"a": "1"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchLabels(tt.workload, tt.selector); got != tt.want {
+				t.Errorf("matchLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuilderGetServiceAccountsWithCloudIdentity(t *testing.T) {
+	b := NewBuilder()
+	_ = b.AddServiceAccount(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "aws-sa", Namespace: "ns",
+			Annotations: map[string]string{"eks.amazonaws.com/role-arn": "arn"},
+		},
+	})
+	_ = b.AddServiceAccount(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "plain-sa", Namespace: "ns"},
+	})
+
+	result := b.GetServiceAccountsWithCloudIdentity()
+	if len(result) != 1 {
+		t.Errorf("expected 1 SA with cloud identity, got %d", len(result))
+	}
+	if result[0].Name != "aws-sa" {
+		t.Errorf("expected aws-sa, got %s", result[0].Name)
+	}
+}
+
+func TestBuilderAddCloudRole(t *testing.T) {
+	b := NewBuilder()
+	err := b.AddCloudRole("custom-id", "my-role", "arn:aws:iam::123:role/r", "aws")
+	if err != nil {
+		t.Fatalf("AddCloudRole() error: %v", err)
+	}
+
+	node := b.graph.GetNode("custom-id")
+	if node == nil {
+		t.Fatal("cloud role node not found")
+	}
+	if node.Metadata.CloudRoleARN != "arn:aws:iam::123:role/r" {
+		t.Errorf("CloudRoleARN = %q", node.Metadata.CloudRoleARN)
+	}
+	if node.Metadata.CloudProvider != "aws" {
+		t.Errorf("CloudProvider = %q", node.Metadata.CloudProvider)
+	}
+}
+
+func TestBuilderAddCloudRoleWithPolicies(t *testing.T) {
+	b := NewBuilder()
+	policies := []CloudPolicy{
+		{Name: "AdminAccess", ARN: "arn:aws:iam::aws:policy/AdminAccess", Type: "managed", IsAdmin: true},
+		{Name: "inline-policy", Type: "inline"},
+	}
+	err := b.AddCloudRoleWithPolicies("id", "role", "arn", "aws", policies)
+	if err != nil {
+		t.Fatalf("AddCloudRoleWithPolicies() error: %v", err)
+	}
+
+	node := b.graph.GetNode("id")
+	if node == nil {
+		t.Fatal("node not found")
+	}
+	if len(node.Metadata.CloudPolicies) != 2 {
+		t.Errorf("CloudPolicies len = %d", len(node.Metadata.CloudPolicies))
+	}
+	if len(node.Metadata.PolicyARNs) != 2 {
+		t.Errorf("PolicyARNs len = %d", len(node.Metadata.PolicyARNs))
+	}
+	// First policy has ARN, second uses Name as fallback
+	if node.Metadata.PolicyARNs[0] != "arn:aws:iam::aws:policy/AdminAccess" {
+		t.Errorf("PolicyARNs[0] = %q", node.Metadata.PolicyARNs[0])
+	}
+	if node.Metadata.PolicyARNs[1] != "inline-policy" {
+		t.Errorf("PolicyARNs[1] = %q", node.Metadata.PolicyARNs[1])
+	}
+}
+
+func TestBuilderAddCloudResource(t *testing.T) {
+	b := NewBuilder()
+	err := b.AddCloudResource("res-id", "s3-bucket", "arn:aws:s3:::mybucket", "aws")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	node := b.graph.GetNode("res-id")
+	if node == nil {
+		t.Fatal("node not found")
+	}
+	if node.Metadata.ResourceKind != "s3-bucket" {
+		t.Errorf("ResourceKind = %q", node.Metadata.ResourceKind)
+	}
+}
+
+func TestBuilderAddCloudAssumeEdge(t *testing.T) {
+	b := NewBuilder()
+	_ = b.AddServiceAccount(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: "ns"},
+	})
+	_ = b.AddCloudRole("cr-id", "role", "arn", "aws")
+
+	saID := GenerateNodeID(NodeServiceAccount, "ns", "sa")
+	err := b.AddCloudAssumeEdge(saID, "cr-id")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	edges := b.graph.GetOutEdges(saID)
+	found := false
+	for _, e := range edges {
+		if e.Type == EdgeAssumes && e.To == "cr-id" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected EdgeAssumes edge")
+	}
+}
+
+func TestBuilderAddCloudAllowEdge(t *testing.T) {
+	b := NewBuilder()
+	_ = b.AddCloudRole("cr-id", "role", "arn", "aws")
+	_ = b.AddCloudResource("res-id", "s3", "arn", "aws")
+
+	err := b.AddCloudAllowEdge("cr-id", "res-id", []string{"s3:GetObject"}, SeverityHigh)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	edges := b.graph.GetOutEdges("cr-id")
+	found := false
+	for _, e := range edges {
+		if e.Type == EdgeAllows && e.To == "res-id" {
+			found = true
+			if e.Metadata.Severity != SeverityHigh {
+				t.Errorf("Severity = %q", e.Metadata.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected EdgeAllows edge")
+	}
+}
+
+func TestExtractPodSecurityContext(t *testing.T) {
+	b := NewBuilder()
+	_ = b.AddServiceAccount(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: "ns"},
+	})
+
+	privileged := true
+	runAsUser := int64(0)
+	readOnly := true
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "priv-dep", Namespace: "ns"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "sa",
+					HostNetwork:        true,
+					HostPID:            true,
+					HostIPC:            true,
+					Volumes: []corev1.Volume{
+						{Name: "host", VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{Path: "/var/run/docker.sock"},
+						}},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  "main",
+							Image: "img",
+							SecurityContext: &corev1.SecurityContext{
+								Privileged:             &privileged,
+								RunAsUser:              &runAsUser,
+								ReadOnlyRootFilesystem: &readOnly,
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{"NET_ADMIN", "SYS_PTRACE"},
+								},
+							},
+							Ports: []corev1.ContainerPort{
+								{HostPort: 8080},
+							},
+							Env: []corev1.EnvVar{
+								{Name: "SECRET", ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{},
+								}},
+							},
+							EnvFrom: []corev1.EnvFromSource{
+								{SecretRef: &corev1.SecretEnvSource{}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	_ = b.AddDeployment(dep)
+
+	node := b.graph.FindNode(NodeWorkload, "ns", "priv-dep")
+	if node == nil {
+		t.Fatal("node not found")
+	}
+	psc := node.Metadata.PodSecurityContext
+	if psc == nil {
+		t.Fatal("PodSecurityContext nil")
+	}
+	if !psc.HostNetwork {
+		t.Error("expected HostNetwork=true")
+	}
+	if !psc.HostPID {
+		t.Error("expected HostPID=true")
+	}
+	if !psc.HostIPC {
+		t.Error("expected HostIPC=true")
+	}
+	if len(psc.HostPaths) != 1 || psc.HostPaths[0] != "/var/run/docker.sock" {
+		t.Errorf("HostPaths = %v", psc.HostPaths)
+	}
+	if len(psc.Containers) != 1 {
+		t.Fatalf("Containers len = %d", len(psc.Containers))
+	}
+	c := psc.Containers[0]
+	if !c.Privileged {
+		t.Error("expected Privileged=true")
+	}
+	if !c.RunAsRoot {
+		t.Error("expected RunAsRoot=true")
+	}
+	if !c.ReadOnlyRootFilesystem {
+		t.Error("expected ReadOnlyRootFilesystem=true")
+	}
+	if len(c.Capabilities) != 2 {
+		t.Errorf("Capabilities = %v", c.Capabilities)
+	}
+	if len(c.HostPorts) != 1 || c.HostPorts[0] != 8080 {
+		t.Errorf("HostPorts = %v", c.HostPorts)
+	}
+	if c.SecretsInEnv != 2 {
+		t.Errorf("SecretsInEnv = %d, want 2", c.SecretsInEnv)
+	}
+	if !c.AllowPrivilegeEscalation {
+		t.Error("expected AllowPrivilegeEscalation=true when AllowPrivilegeEscalation is nil")
+	}
+}
+
+func TestBuilderAddStatefulSet(t *testing.T) {
+	b := NewBuilder()
+	_ = b.AddServiceAccount(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: "ns"},
+	})
+
+	replicas := int32(3)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "ns"},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "sa",
+					Containers:         []corev1.Container{{Name: "db", Image: "pg"}},
+				},
+			},
+		},
+	}
+	if err := b.AddStatefulSet(sts); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	node := b.graph.FindNode(NodeWorkload, "ns", "db")
+	if node == nil {
+		t.Fatal("node not found")
+	}
+	if node.Metadata.WorkloadKind != "StatefulSet" {
+		t.Errorf("WorkloadKind = %q", node.Metadata.WorkloadKind)
+	}
+	if node.Metadata.Replicas != 3 {
+		t.Errorf("Replicas = %d", node.Metadata.Replicas)
+	}
+}
+
+func TestBuilderAddDaemonSet(t *testing.T) {
+	b := NewBuilder()
+	_ = b.AddServiceAccount(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"},
+	})
+
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "ns"},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "agent", Image: "img"}},
+				},
+			},
+		},
+	}
+	if err := b.AddDaemonSet(ds); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	node := b.graph.FindNode(NodeWorkload, "ns", "agent")
+	if node == nil {
+		t.Fatal("node not found")
+	}
+	if node.Metadata.WorkloadKind != "DaemonSet" {
+		t.Errorf("WorkloadKind = %q", node.Metadata.WorkloadKind)
+	}
+
+	// Should default to "default" SA
+	saID := GenerateNodeID(NodeServiceAccount, "ns", "default")
+	edges := b.graph.GetOutEdges(node.ID)
+	found := false
+	for _, e := range edges {
+		if e.Type == EdgeUses && e.To == saID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected EdgeUses to default SA")
+	}
+}
+
+func TestBuilderAddJob(t *testing.T) {
+	b := NewBuilder()
+	_ = b.AddServiceAccount(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "job-sa", Namespace: "ns"},
+	})
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "myjob", Namespace: "ns"},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "job-sa",
+					Containers:         []corev1.Container{{Name: "worker", Image: "img"}},
+				},
+			},
+		},
+	}
+	if err := b.AddJob(job); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	node := b.graph.FindNode(NodeWorkload, "ns", "myjob")
+	if node == nil {
+		t.Fatal("node not found")
+	}
+	if node.Metadata.WorkloadKind != "Job" {
+		t.Errorf("WorkloadKind = %q", node.Metadata.WorkloadKind)
+	}
+}
+
+func TestBuilderAddCronJob(t *testing.T) {
+	b := NewBuilder()
+	_ = b.AddServiceAccount(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"},
+	})
+
+	cj := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "ns"},
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "backup", Image: "img"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := b.AddCronJob(cj); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	node := b.graph.FindNode(NodeWorkload, "ns", "backup")
+	if node == nil {
+		t.Fatal("node not found")
+	}
+	if node.Metadata.WorkloadKind != "CronJob" {
+		t.Errorf("WorkloadKind = %q", node.Metadata.WorkloadKind)
+	}
+}
+
+func TestBuilderAddPod(t *testing.T) {
+	b := NewBuilder()
+	_ = b.AddServiceAccount(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns"},
+	})
+
+	// Pod with owner references should be skipped
+	ownedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "owned",
+			Namespace: "ns",
+			OwnerReferences: []metav1.OwnerReference{
+				{Name: "dep", Kind: "Deployment"},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c", Image: "img"}},
+		},
+	}
+	if err := b.AddPod(ownedPod); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if b.graph.FindNode(NodeWorkload, "ns", "owned") != nil {
+		t.Error("owned pod should be skipped")
+	}
+
+	// Standalone pod
+	expSeconds := int64(3600)
+	standalonePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "standalone", Namespace: "ns"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c", Image: "img"}},
+			Volumes: []corev1.Volume{
+				{
+					Name: "token",
+					VolumeSource: corev1.VolumeSource{
+						Projected: &corev1.ProjectedVolumeSource{
+							Sources: []corev1.VolumeProjection{
+								{
+									ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+										Audience:          "api.example.com",
+										ExpirationSeconds: &expSeconds,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := b.AddPod(standalonePod); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	node := b.graph.FindNode(NodeWorkload, "ns", "standalone")
+	if node == nil {
+		t.Fatal("standalone pod node not found")
+	}
+	if node.Metadata.WorkloadKind != "Pod" {
+		t.Errorf("WorkloadKind = %q", node.Metadata.WorkloadKind)
+	}
+	if node.Metadata.Replicas != 1 {
+		t.Errorf("Replicas = %d, want 1", node.Metadata.Replicas)
+	}
+	if node.Metadata.TokenAudience != "api.example.com" {
+		t.Errorf("TokenAudience = %q", node.Metadata.TokenAudience)
+	}
+	if node.Metadata.TokenExpirationSeconds != 3600 {
+		t.Errorf("TokenExpirationSeconds = %d", node.Metadata.TokenExpirationSeconds)
+	}
+}
+
+func TestBuilderResourceEdgesWithResourceNames(t *testing.T) {
+	b := NewBuilder()
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "secret-reader", Namespace: "ns"},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"secrets"},
+				ResourceNames: []string{"my-secret"},
+				Verbs:         []string{"get"},
+			},
+		},
+	}
+	_ = b.AddRole(role)
+	b.BuildResourceEdges()
+
+	roleID := GenerateNodeID(NodeRole, "ns", "secret-reader")
+	edges := b.graph.GetOutEdges(roleID)
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 edge, got %d", len(edges))
+	}
+	if len(edges[0].Metadata.ResourceNames) != 1 || edges[0].Metadata.ResourceNames[0] != "my-secret" {
+		t.Errorf("ResourceNames = %v", edges[0].Metadata.ResourceNames)
+	}
+}
+
+func TestBuilderResourceEdgesClusterRoleWithApiGroup(t *testing.T) {
+	b := NewBuilder()
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "deploy-manager"},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments"},
+				Verbs:     []string{"get", "create", "update"},
+			},
+		},
+	}
+	_ = b.AddClusterRole(cr)
+	b.BuildResourceEdges()
+
+	// Resource node should be cluster-scoped (empty namespace for ClusterRole)
+	resNode := b.graph.FindNode(NodeK8sResource, "", "deployments")
+	if resNode == nil {
+		t.Fatal("resource node not created")
+	}
+	if resNode.Labels["apiGroup"] != "apps" {
+		t.Errorf("apiGroup label = %q", resNode.Labels["apiGroup"])
+	}
+}
+
+func TestConvertRules(t *testing.T) {
+	policyRules := []rbacv1.PolicyRule{
+		{
+			APIGroups:     []string{"", "apps"},
+			Resources:     []string{"pods", "deployments"},
+			ResourceNames: []string{"my-pod"},
+			Verbs:         []string{"get", "list"},
+		},
+	}
+
+	rules := convertRules(policyRules)
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
+	}
+	r := rules[0]
+	if len(r.APIGroups) != 2 {
+		t.Errorf("APIGroups = %v", r.APIGroups)
+	}
+	if len(r.Resources) != 2 {
+		t.Errorf("Resources = %v", r.Resources)
+	}
+	if len(r.ResourceNames) != 1 || r.ResourceNames[0] != "my-pod" {
+		t.Errorf("ResourceNames = %v", r.ResourceNames)
+	}
+	if len(r.Verbs) != 2 {
+		t.Errorf("Verbs = %v", r.Verbs)
+	}
+}
+
+func TestBuilderAddNetworkPolicyEgressRules(t *testing.T) {
+	b := NewBuilder()
+	protocol := corev1.ProtocolTCP
+	port := intstr.FromInt32(443)
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "egress-np", Namespace: "ns"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"env": "prod"},
+							},
+							IPBlock: &networkingv1.IPBlock{CIDR: "10.0.0.0/8"},
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &protocol, Port: &port},
+					},
+				},
+			},
+		},
+	}
+	_ = b.AddNetworkPolicy(np)
+
+	node := b.graph.FindNode(NodeNetworkPolicy, "ns", "egress-np")
+	if node == nil {
+		t.Fatal("node not found")
+	}
+	npInfo := node.Metadata.NetworkPolicy
+	if len(npInfo.EgressRules) != 1 {
+		t.Fatalf("EgressRules len = %d", len(npInfo.EgressRules))
+	}
+	er := npInfo.EgressRules[0]
+	if er.ToNamespaceSelector["env"] != "prod" {
+		t.Error("ToNamespaceSelector not set")
+	}
+	if er.ToIPBlock != "10.0.0.0/8" {
+		t.Errorf("ToIPBlock = %q", er.ToIPBlock)
+	}
+	if len(er.Ports) != 1 || er.Ports[0].Port != "443" {
+		t.Errorf("Ports = %v", er.Ports)
+	}
+}
+
+func TestBuilderAddNetworkPolicyAllowAllEgress(t *testing.T) {
+	b := NewBuilder()
+	np := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "allow-egress", Namespace: "ns"},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{}, // empty to + empty ports = allow all
+			},
+		},
+	}
+	_ = b.AddNetworkPolicy(np)
+
+	node := b.graph.FindNode(NodeNetworkPolicy, "ns", "allow-egress")
+	if !node.Metadata.NetworkPolicy.AllowAllEgress {
+		t.Error("expected AllowAllEgress=true")
+	}
+}
+
+// Test that EdgeUses properly tracks SA-to-workload mapping
+func TestGraphSAToWorkloadTracking(t *testing.T) {
+	g := New()
+	sa := NewNode(NodeServiceAccount, "ns", "sa")
+	dep1 := NewNode(NodeWorkload, "ns", "dep1")
+	dep2 := NewNode(NodeWorkload, "ns", "dep2")
+	_ = g.AddNode(sa)
+	_ = g.AddNode(dep1)
+	_ = g.AddNode(dep2)
+
+	// Only EdgeUses should track
+	_ = g.AddEdge(NewEdge(EdgeUses, dep1.ID, sa.ID))
+	_ = g.AddEdge(NewEdge(EdgeUses, dep2.ID, sa.ID))
+	_ = g.AddEdge(NewEdge(EdgeBinds, sa.ID, sa.ID)) // non-uses edge
+
+	workloads := g.GetWorkloadsUsingSA(sa.ID)
+	if len(workloads) != 2 {
+		t.Errorf("expected 2, got %d", len(workloads))
+	}
+}
+
+// Test Graph with DistroProfile
+func TestGraphDistroProfile(t *testing.T) {
+	g := New()
+	if g.DistroProfile != nil {
+		t.Error("DistroProfile should be nil initially")
+	}
+
+	g.DistroProfile = &GraphDistroProfile{
+		Platform:      "EKS",
+		CloudProvider: "aws",
+		FeatureFlags:  map[string]bool{"irsa": true},
+	}
+
+	if g.DistroProfile.Platform != "EKS" {
+		t.Errorf("Platform = %q", g.DistroProfile.Platform)
+	}
+}
+
+// Test ClassifyEdgeSeverity for statefulsets and daemonsets
+func TestClassifyEdgeSeverityWorkloadTypes(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceKind string
+		verbs        []string
+		want         Severity
+	}{
+		{"statefulsets dangerous", "statefulsets", []string{"create"}, SeverityHigh},
+		{"daemonsets dangerous", "daemonsets", []string{"delete"}, SeverityHigh},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Edge{Type: EdgeGrants, Metadata: EdgeMeta{Verbs: tt.verbs}}
+			n := &Node{Type: NodeK8sResource, Metadata: NodeMetadata{ResourceKind: tt.resourceKind}}
+			got := ClassifyEdgeSeverity(e, n)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test RoleBinding with SA subject that has no explicit namespace (inherits binding NS)
+func TestBuilderRoleBindingSADefaultNamespace(t *testing.T) {
+	b := NewBuilder()
+	_ = b.AddServiceAccount(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "sa", Namespace: "myns"},
+	})
+	_ = b.AddRole(&rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "myns"},
+		Rules:      []rbacv1.PolicyRule{{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get"}}},
+	})
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "rb", Namespace: "myns"},
+		RoleRef:    rbacv1.RoleRef{Kind: "Role", Name: "r"},
+		Subjects: []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: "sa"}, // no namespace -> should use rb.Namespace
+		},
+	}
+	_ = b.AddRoleBinding(rb)
+
+	saID := GenerateNodeID(NodeServiceAccount, "myns", "sa")
+	roleID := GenerateNodeID(NodeRole, "myns", "r")
+	edges := b.graph.GetOutEdges(saID)
+	found := false
+	for _, e := range edges {
+		if e.Type == EdgeBinds && e.To == roleID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected SA to bind to role when subject has no explicit namespace")
+	}
+}
+
+// Test error message content
+func TestGraphAddNodeDuplicateErrorMessage(t *testing.T) {
+	g := New()
+	n := NewNode(NodeServiceAccount, "ns", "sa")
+	_ = g.AddNode(n)
+
+	err := g.AddNode(n)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error = %q, expected 'already exists'", err.Error())
+	}
+}
+
+func TestGraphAddEdgeMissingNodeErrorMessages(t *testing.T) {
+	g := New()
+	n := NewNode(NodeServiceAccount, "ns", "sa")
+	_ = g.AddNode(n)
+
+	e1 := NewEdge(EdgeUses, "missing", n.ID)
+	err1 := g.AddEdge(e1)
+	if err1 == nil || !strings.Contains(err1.Error(), "source node") {
+		t.Errorf("err1 = %v, expected source node error", err1)
+	}
+
+	e2 := NewEdge(EdgeUses, n.ID, "missing")
+	err2 := g.AddEdge(e2)
+	if err2 == nil || !strings.Contains(err2.Error(), "target node") {
+		t.Errorf("err2 = %v, expected target node error", err2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func ptrIntStr(v intstr.IntOrString) *intstr.IntOrString {
+	return &v
+}
+
+// Ensure batchv1 import is used
+var _ = &batchv1.Job{}

--- a/pkg/output/json_test.go
+++ b/pkg/output/json_test.go
@@ -1,0 +1,459 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/analysis"
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+// helpers
+
+func makeWorkloadNode(ns, name, kind string) *graph.Node {
+	n := graph.NewNode(graph.NodeWorkload, ns, name)
+	n.Metadata.WorkloadKind = kind
+	return n
+}
+
+func makeSANode(ns, name string) *graph.Node {
+	return graph.NewNode(graph.NodeServiceAccount, ns, name)
+}
+
+func makeResourceNode(ns, name, resourceKind string) *graph.Node {
+	n := graph.NewNode(graph.NodeK8sResource, ns, name)
+	n.Metadata.ResourceKind = resourceKind
+	return n
+}
+
+func sampleBlastResult() *analysis.BlastResult {
+	return &analysis.BlastResult{
+		SourceWorkload: makeWorkloadNode("default", "nginx", "Deployment"),
+		ServiceAccount: makeSANode("default", "nginx-sa"),
+		K8sResources: []analysis.ResourceAccess{
+			{
+				Resource: makeResourceNode("default", "secrets", "secrets"),
+				Verbs:    []string{"get", "list"},
+				ViaRole:  "reader-role",
+				Severity: graph.SeverityCritical,
+			},
+			{
+				Resource: makeResourceNode("", "nodes", "nodes"),
+				Verbs:    []string{"get"},
+				ViaRole:  "node-reader",
+				Severity: graph.SeverityLow,
+			},
+		},
+		CloudRoles: []analysis.CloudAccess{
+			{
+				Provider: "aws",
+				RoleARN:  "arn:aws:iam::123456789012:role/my-role",
+				Severity: graph.SeverityHigh,
+				Policies: []analysis.CloudPolicy{
+					{
+						Name:    "S3FullAccess",
+						IsAdmin: false,
+						Actions: []string{"s3:GetObject", "s3:PutObject"},
+					},
+				},
+				BlastRadius: []string{"Read/Write access to S3 buckets"},
+			},
+		},
+		TotalK8sPerms:   3,
+		TotalCloudPerms: 1,
+		MaxSeverity:     graph.SeverityCritical,
+	}
+}
+
+// ---------- WriteStats ----------
+
+func TestJSONWriter_WriteStats(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewJSONWriter(&buf)
+
+	stats := graph.GraphStats{
+		TotalNodes: 10,
+		TotalEdges: 15,
+		NodeCounts: map[graph.NodeType]int{
+			graph.NodeWorkload:       3,
+			graph.NodeServiceAccount: 4,
+			graph.NodeRole:           3,
+		},
+		EdgeCounts: map[graph.EdgeType]int{
+			graph.EdgeUses:   3,
+			graph.EdgeBinds:  4,
+			graph.EdgeGrants: 8,
+		},
+	}
+
+	if err := w.WriteStats(stats); err != nil {
+		t.Fatalf("WriteStats error: %v", err)
+	}
+
+	if !json.Valid(buf.Bytes()) {
+		t.Fatal("WriteStats produced invalid JSON")
+	}
+
+	var decoded graph.GraphStats
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("cannot unmarshal stats: %v", err)
+	}
+	if decoded.TotalNodes != 10 {
+		t.Errorf("TotalNodes = %d, want 10", decoded.TotalNodes)
+	}
+	if decoded.TotalEdges != 15 {
+		t.Errorf("TotalEdges = %d, want 15", decoded.TotalEdges)
+	}
+}
+
+// ---------- WriteGraph ----------
+
+func TestJSONWriter_WriteGraph(t *testing.T) {
+	g := graph.New()
+	n1 := graph.NewNode(graph.NodeWorkload, "default", "web")
+	n1.Metadata.WorkloadKind = "Deployment"
+	n2 := graph.NewNode(graph.NodeServiceAccount, "default", "web-sa")
+	g.AddNode(n1)
+	g.AddNode(n2)
+
+	e := graph.NewEdge(graph.EdgeUses, n1.ID, n2.ID)
+	g.AddEdge(e)
+
+	var buf bytes.Buffer
+	w := NewJSONWriter(&buf)
+	if err := w.WriteGraph(g); err != nil {
+		t.Fatalf("WriteGraph error: %v", err)
+	}
+
+	if !json.Valid(buf.Bytes()) {
+		t.Fatal("WriteGraph produced invalid JSON")
+	}
+
+	var raw map[string]json.RawMessage
+	json.Unmarshal(buf.Bytes(), &raw)
+	for _, key := range []string{"nodes", "edges", "stats"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing key %q in graph JSON output", key)
+		}
+	}
+}
+
+// ---------- WriteBlastResult ----------
+
+func TestJSONWriter_WriteBlastResult(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewJSONWriter(&buf)
+
+	if err := w.WriteBlastResult(sampleBlastResult()); err != nil {
+		t.Fatalf("WriteBlastResult error: %v", err)
+	}
+
+	if !json.Valid(buf.Bytes()) {
+		t.Fatal("WriteBlastResult produced invalid JSON")
+	}
+
+	var raw map[string]json.RawMessage
+	json.Unmarshal(buf.Bytes(), &raw)
+
+	requiredKeys := []string{
+		"workload", "service_account", "k8s_resources",
+		"cloud_roles", "blast_radius", "total_k8s_permissions",
+		"total_cloud_permissions", "max_severity",
+	}
+	for _, key := range requiredKeys {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing key %q in blast result JSON", key)
+		}
+	}
+}
+
+// ---------- WriteBlastResults ----------
+
+func TestJSONWriter_WriteBlastResults(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewJSONWriter(&buf)
+
+	results := []*analysis.BlastResult{sampleBlastResult()}
+	if err := w.WriteBlastResults(results); err != nil {
+		t.Fatalf("WriteBlastResults error: %v", err)
+	}
+
+	if !json.Valid(buf.Bytes()) {
+		t.Fatal("WriteBlastResults produced invalid JSON")
+	}
+
+	var arr []json.RawMessage
+	json.Unmarshal(buf.Bytes(), &arr)
+	if len(arr) != 1 {
+		t.Errorf("expected 1 element, got %d", len(arr))
+	}
+}
+
+func TestJSONWriter_WriteBlastResults_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewJSONWriter(&buf)
+
+	if err := w.WriteBlastResults(nil); err != nil {
+		t.Fatalf("WriteBlastResults error: %v", err)
+	}
+	if !json.Valid(buf.Bytes()) {
+		t.Fatal("invalid JSON for empty blast results")
+	}
+}
+
+// ---------- WriteRBACAuditResult ----------
+
+func TestJSONWriter_WriteRBACAuditResult(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewJSONWriter(&buf)
+
+	result := &analysis.RBACAuditResult{
+		Findings: []analysis.RBACFinding{
+			{
+				CheckID:     "RBAC001",
+				Category:    analysis.CategoryPrivilegeEscalation,
+				Severity:    graph.SeverityCritical,
+				Title:       "Wildcard permissions",
+				Description: "ServiceAccount has wildcard permissions",
+				Affected: []analysis.AffectedResource{
+					{Kind: "ServiceAccount", Namespace: "default", Name: "admin-sa", Details: "has * verbs"},
+				},
+				Remediation: "Restrict verbs to specific actions",
+			},
+		},
+		Summary: analysis.AuditSummary{
+			Critical: 1,
+		},
+		ChecksRun:     []string{"RBAC001"},
+		TotalFindings: 1,
+	}
+
+	if err := w.WriteRBACAuditResult(result); err != nil {
+		t.Fatalf("WriteRBACAuditResult error: %v", err)
+	}
+
+	if !json.Valid(buf.Bytes()) {
+		t.Fatal("invalid JSON")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "RBAC001") {
+		t.Error("output should contain check ID RBAC001")
+	}
+}
+
+// ---------- WritePodSecurityResult ----------
+
+func TestJSONWriter_WritePodSecurityResult(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewJSONWriter(&buf)
+
+	result := &analysis.PodSecurityResult{
+		Findings: []analysis.PodSecurityFinding{
+			{
+				CheckID:     "PSS001",
+				Category:    "privilege_escalation",
+				Severity:    graph.SeverityCritical,
+				Title:       "Privileged Containers",
+				Description: "Container running in privileged mode",
+				Affected: []analysis.AffectedWorkload{
+					{Kind: "Deployment", Namespace: "default", Name: "web", Container: "app", Details: "privileged: true"},
+				},
+				Remediation: "Remove privileged: true",
+			},
+		},
+		Summary: analysis.PodSecuritySummary{
+			Critical:   1,
+			ByCategory: map[string]int{"privilege_escalation": 1},
+		},
+		ChecksRun:    []string{"PSS001"},
+		TotalFindings: 1,
+	}
+
+	if err := w.WritePodSecurityResult(result); err != nil {
+		t.Fatalf("WritePodSecurityResult error: %v", err)
+	}
+	if !json.Valid(buf.Bytes()) {
+		t.Fatal("invalid JSON")
+	}
+	if !strings.Contains(buf.String(), "PSS001") {
+		t.Error("output should contain PSS001")
+	}
+}
+
+// ---------- WriteNetworkPolicyResult ----------
+
+func TestJSONWriter_WriteNetworkPolicyResult(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewJSONWriter(&buf)
+
+	result := &analysis.NetworkPolicyResult{
+		Findings: []analysis.NetworkPolicyFinding{
+			{
+				CheckID:     "NET001",
+				Category:    "missing_policy",
+				Severity:    graph.SeverityHigh,
+				Title:       "No Network Policy",
+				Description: "Workload has no network policy",
+				Affected: []analysis.AffectedNetworkResource{
+					{Kind: "Deployment", Namespace: "default", Name: "web", Details: "no policy", Services: []string{"web-svc"}},
+				},
+				Remediation: "Create NetworkPolicy",
+			},
+		},
+		Summary: analysis.NetworkPolicySummary{
+			High:                   1,
+			TotalNetworkPolicies:   2,
+			WorkloadsWithoutPolicy: 1,
+			ByCategory:            map[string]int{"missing_policy": 1},
+		},
+		ChecksRun:    []string{"NET001"},
+		TotalFindings: 1,
+	}
+
+	if err := w.WriteNetworkPolicyResult(result); err != nil {
+		t.Fatalf("WriteNetworkPolicyResult error: %v", err)
+	}
+	if !json.Valid(buf.Bytes()) {
+		t.Fatal("invalid JSON")
+	}
+	if !strings.Contains(buf.String(), "NET001") {
+		t.Error("output should contain NET001")
+	}
+}
+
+// ---------- convertBlastResult ----------
+
+func TestConvertBlastResult_NilFields(t *testing.T) {
+	r := &analysis.BlastResult{
+		TotalK8sPerms: 0,
+		MaxSeverity:   graph.SeverityLow,
+	}
+	result := convertBlastResult(r)
+	if result.Workload != nil {
+		t.Error("expected nil workload")
+	}
+	if result.ServiceAccount != nil {
+		t.Error("expected nil service account")
+	}
+	if result.TotalK8sPerms != 0 {
+		t.Errorf("expected 0 perms, got %d", result.TotalK8sPerms)
+	}
+}
+
+func TestConvertBlastResult_WithData(t *testing.T) {
+	r := sampleBlastResult()
+	result := convertBlastResult(r)
+
+	if result.Workload == nil {
+		t.Fatal("workload should not be nil")
+	}
+	if result.Workload.Name != "nginx" {
+		t.Errorf("workload name = %q, want %q", result.Workload.Name, "nginx")
+	}
+	if result.Workload.Kind != "Deployment" {
+		t.Errorf("workload kind = %q, want %q", result.Workload.Kind, "Deployment")
+	}
+	if result.ServiceAccount == nil {
+		t.Fatal("service account should not be nil")
+	}
+	if result.ServiceAccount.Name != "nginx-sa" {
+		t.Errorf("sa name = %q, want %q", result.ServiceAccount.Name, "nginx-sa")
+	}
+	if len(result.K8sResources) != 2 {
+		t.Errorf("expected 2 k8s resources, got %d", len(result.K8sResources))
+	}
+	if len(result.CloudRoles) != 1 {
+		t.Errorf("expected 1 cloud role, got %d", len(result.CloudRoles))
+	}
+	if result.MaxSeverity != graph.SeverityCritical {
+		t.Errorf("max severity = %q, want %q", result.MaxSeverity, graph.SeverityCritical)
+	}
+}
+
+// ---------- describeK8sBlastRadius ----------
+
+func TestDescribeK8sBlastRadius_Secrets(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		ns       string
+		verbs    []string
+		severity graph.Severity
+		contains string
+	}{
+		{"secrets read", "secrets", "default", []string{"get", "list"}, graph.SeverityCritical, "READ ALL SECRETS"},
+		{"secrets wildcard", "secrets", "", []string{"*"}, graph.SeverityCritical, "READ ALL SECRETS"},
+		{"secrets write only", "secrets", "kube-system", []string{"create"}, graph.SeverityHigh, "access to secrets"},
+		{"pods write", "pods", "default", []string{"create"}, graph.SeverityHigh, "CREATE/MODIFY PODS"},
+		{"pods read", "pods", "ns1", []string{"get"}, graph.SeverityLow, "Read access to pods"},
+		{"pods/exec", "pods/exec", "default", []string{"create"}, graph.SeverityHigh, "EXEC INTO PODS"},
+		{"deployments write", "deployments", "default", []string{"update"}, graph.SeverityHigh, "modify deployments"},
+		{"roles write", "roles", "", []string{"create"}, graph.SeverityCritical, "MODIFY RBAC"},
+		{"nodes write", "nodes", "", []string{"update"}, graph.SeverityHigh, "modify NODES"},
+		{"nodes read", "nodes", "", []string{"get"}, graph.SeverityLow, "access to nodes"},
+		{"custom critical", "custom-resource", "ns1", []string{"get"}, graph.SeverityCritical, "CRITICAL"},
+		{"custom low", "configmaps", "ns1", []string{"get"}, graph.SeverityLow, "access to configmaps"},
+		{"cluster wide scope", "secrets", "", []string{"get"}, graph.SeverityCritical, "cluster-wide"},
+		{"full control wildcard", "pods", "ns1", []string{"*"}, graph.SeverityHigh, "CREATE/MODIFY PODS"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := describeK8sBlastRadius(tc.resource, tc.ns, tc.verbs, tc.severity)
+			if !strings.Contains(got, tc.contains) {
+				t.Errorf("describeK8sBlastRadius(%q, %q, %v, %q) = %q, want to contain %q",
+					tc.resource, tc.ns, tc.verbs, tc.severity, got, tc.contains)
+			}
+		})
+	}
+}
+
+func TestDescribeK8sBlastRadius_ReadWriteDelete(t *testing.T) {
+	got := describeK8sBlastRadius("configmaps", "default", []string{"get", "create", "delete"}, graph.SeverityMedium)
+	if !strings.Contains(got, "Read/Write/Delete") {
+		t.Errorf("expected Read/Write/Delete, got %q", got)
+	}
+}
+
+func TestDescribeK8sBlastRadius_ReadDelete(t *testing.T) {
+	got := describeK8sBlastRadius("configmaps", "default", []string{"get", "delete"}, graph.SeverityMedium)
+	if !strings.Contains(got, "Read/Delete") {
+		t.Errorf("expected Read/Delete, got %q", got)
+	}
+}
+
+// ---------- WriteCloudAuditResult ----------
+
+func TestJSONWriter_WriteCloudAuditResult(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewJSONWriter(&buf)
+
+	result := &analysis.CloudIAMAuditResult{
+		Findings: []analysis.CloudIAMFinding{
+			{
+				Provider:    "aws",
+				Category:    analysis.CloudCategoryAdminAccess,
+				Severity:    graph.SeverityCritical,
+				Title:       "Admin policy attached",
+				Description: "Role has AdministratorAccess policy",
+				RoleARN:     "arn:aws:iam::123456789012:role/admin-role",
+				Remediation: "Remove admin policy",
+			},
+		},
+		Summary: analysis.CloudIAMSummary{
+			Critical:   1,
+			ByProvider: map[string]int{"aws": 1},
+		},
+		AnalyzedRoles: 5,
+	}
+
+	if err := w.WriteCloudAuditResult(result); err != nil {
+		t.Fatalf("WriteCloudAuditResult error: %v", err)
+	}
+	if !json.Valid(buf.Bytes()) {
+		t.Fatal("invalid JSON")
+	}
+}

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -1,0 +1,58 @@
+package output
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNewWriter_Table(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf, FormatTable)
+	if _, ok := w.(*TableWriter); !ok {
+		t.Errorf("NewWriter(FormatTable) returned %T, want *TableWriter", w)
+	}
+}
+
+func TestNewWriter_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf, FormatJSON)
+	if _, ok := w.(*JSONWriter); !ok {
+		t.Errorf("NewWriter(FormatJSON) returned %T, want *JSONWriter", w)
+	}
+}
+
+func TestNewWriter_DOT(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf, FormatDOT)
+	if _, ok := w.(*DOTWriter); !ok {
+		t.Errorf("NewWriter(FormatDOT) returned %T, want *DOTWriter", w)
+	}
+}
+
+func TestNewWriter_UnknownDefaultsToTable(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf, Format("yaml"))
+	if _, ok := w.(*TableWriter); !ok {
+		t.Errorf("NewWriter(unknown format) returned %T, want *TableWriter", w)
+	}
+}
+
+func TestNewWriter_EmptyDefaultsToTable(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf, Format(""))
+	if _, ok := w.(*TableWriter); !ok {
+		t.Errorf("NewWriter(empty) returned %T, want *TableWriter", w)
+	}
+}
+
+func TestFormatConstants(t *testing.T) {
+	if FormatTable != "table" {
+		t.Errorf("FormatTable = %q, want %q", FormatTable, "table")
+	}
+	if FormatJSON != "json" {
+		t.Errorf("FormatJSON = %q, want %q", FormatJSON, "json")
+	}
+	if FormatDOT != "dot" {
+		t.Errorf("FormatDOT = %q, want %q", FormatDOT, "dot")
+	}
+}

--- a/pkg/output/sarif_test.go
+++ b/pkg/output/sarif_test.go
@@ -1,0 +1,236 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/analysis"
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+func TestSARIFWriter_WriteCombinedResults_AllNil(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewSARIFWriter(&buf, "0.1.0")
+
+	if err := w.WriteCombinedResults(nil, nil, nil, nil); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if !json.Valid(buf.Bytes()) {
+		t.Fatal("invalid JSON")
+	}
+
+	var doc sarifDocument
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if doc.Version != "2.1.0" {
+		t.Errorf("version = %q, want %q", doc.Version, "2.1.0")
+	}
+	if len(doc.Runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(doc.Runs))
+	}
+	if len(doc.Runs[0].Results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(doc.Runs[0].Results))
+	}
+	if doc.Runs[0].Tool.Driver.Name != "identity-chain" {
+		t.Errorf("tool name = %q, want %q", doc.Runs[0].Tool.Driver.Name, "identity-chain")
+	}
+	if doc.Runs[0].Tool.Driver.Version != "0.1.0" {
+		t.Errorf("tool version = %q, want %q", doc.Runs[0].Tool.Driver.Version, "0.1.0")
+	}
+}
+
+func TestSARIFWriter_WriteCombinedResults_WithFindings(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewSARIFWriter(&buf, "1.0.0")
+
+	rbac := &analysis.RBACAuditResult{
+		Findings: []analysis.RBACFinding{
+			{
+				CheckID:     "RBAC001",
+				Severity:    graph.SeverityCritical,
+				Title:       "Wildcard",
+				Description: "SA has wildcard",
+			},
+		},
+	}
+
+	podSec := &analysis.PodSecurityResult{
+		Findings: []analysis.PodSecurityFinding{
+			{
+				CheckID:     "PSS001",
+				Severity:    graph.SeverityHigh,
+				Title:       "Privileged",
+				Description: "Container is privileged",
+			},
+		},
+	}
+
+	netPol := &analysis.NetworkPolicyResult{
+		Findings: []analysis.NetworkPolicyFinding{
+			{
+				CheckID:     "NET001",
+				Severity:    graph.SeverityMedium,
+				Title:       "No policy",
+				Description: "Missing network policy",
+			},
+		},
+	}
+
+	cloud := &analysis.CloudIAMAuditResult{
+		Findings: []analysis.CloudIAMFinding{
+			{
+				Category:    analysis.CloudCategoryAdminAccess,
+				Severity:    graph.SeverityLow,
+				Title:       "Unused role",
+				Description: "Role not in use",
+			},
+		},
+	}
+
+	if err := w.WriteCombinedResults(rbac, podSec, netPol, cloud); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if !json.Valid(buf.Bytes()) {
+		t.Fatal("invalid JSON")
+	}
+
+	var doc sarifDocument
+	json.Unmarshal(buf.Bytes(), &doc)
+
+	if len(doc.Runs[0].Results) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(doc.Runs[0].Results))
+	}
+
+	// Verify each finding mapped correctly
+	r0 := doc.Runs[0].Results[0]
+	if r0.RuleID != "RBAC001" {
+		t.Errorf("result[0].ruleId = %q, want RBAC001", r0.RuleID)
+	}
+	if r0.Level != "error" {
+		t.Errorf("critical severity should map to 'error', got %q", r0.Level)
+	}
+	if r0.Kind != "fail" {
+		t.Errorf("kind should be 'fail', got %q", r0.Kind)
+	}
+
+	r1 := doc.Runs[0].Results[1]
+	if r1.Level != "error" {
+		t.Errorf("high severity should map to 'error', got %q", r1.Level)
+	}
+
+	r2 := doc.Runs[0].Results[2]
+	if r2.Level != "warning" {
+		t.Errorf("medium severity should map to 'warning', got %q", r2.Level)
+	}
+
+	r3 := doc.Runs[0].Results[3]
+	if r3.Level != "note" {
+		t.Errorf("low severity should map to 'note', got %q", r3.Level)
+	}
+
+	// Cloud finding ruleId should be the category string
+	if r3.RuleID != string(analysis.CloudCategoryAdminAccess) {
+		t.Errorf("cloud finding ruleId = %q, want %q", r3.RuleID, string(analysis.CloudCategoryAdminAccess))
+	}
+}
+
+func TestSARIFWriter_WriteCombinedResults_MessageFormat(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewSARIFWriter(&buf, "1.0.0")
+
+	rbac := &analysis.RBACAuditResult{
+		Findings: []analysis.RBACFinding{
+			{
+				CheckID:     "RBAC002",
+				Severity:    graph.SeverityHigh,
+				Title:       "Over-permissive",
+				Description: "Too many permissions",
+			},
+		},
+	}
+
+	w.WriteCombinedResults(rbac, nil, nil, nil)
+
+	out := buf.String()
+	// Message should be "Title: Description"
+	if !strings.Contains(out, "Over-permissive: Too many permissions") {
+		t.Errorf("message should contain 'Title: Description', got:\n%s", out)
+	}
+}
+
+func TestSARIFWriter_SchemaURI(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewSARIFWriter(&buf, "1.0.0")
+	w.WriteCombinedResults(nil, nil, nil, nil)
+
+	var doc sarifDocument
+	json.Unmarshal(buf.Bytes(), &doc)
+
+	if doc.Schema != "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json" {
+		t.Errorf("unexpected schema URI: %q", doc.Schema)
+	}
+}
+
+func TestSARIFWriter_InformationURI(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewSARIFWriter(&buf, "1.0.0")
+	w.WriteCombinedResults(nil, nil, nil, nil)
+
+	var doc sarifDocument
+	json.Unmarshal(buf.Bytes(), &doc)
+
+	if doc.Runs[0].Tool.Driver.InformationURI != "https://github.com/nelssec/identity-chain" {
+		t.Errorf("unexpected informationUri: %q", doc.Runs[0].Tool.Driver.InformationURI)
+	}
+}
+
+// ---------- severityToSARIFLevel ----------
+
+func TestSeverityToSARIFLevel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"critical", "error"},
+		{"high", "error"},
+		{"medium", "warning"},
+		{"low", "note"},
+		{"info", "none"},
+		{"", "none"},
+		{"unknown", "none"},
+	}
+	for _, tc := range tests {
+		got := severityToSARIFLevel(tc.input)
+		if got != tc.want {
+			t.Errorf("severityToSARIFLevel(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestSARIFWriter_PartialNilInputs(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewSARIFWriter(&buf, "0.2.0")
+
+	rbac := &analysis.RBACAuditResult{
+		Findings: []analysis.RBACFinding{
+			{CheckID: "RBAC010", Severity: graph.SeverityMedium, Title: "Test", Description: "desc"},
+		},
+	}
+
+	if err := w.WriteCombinedResults(rbac, nil, nil, nil); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	var doc sarifDocument
+	json.Unmarshal(buf.Bytes(), &doc)
+
+	if len(doc.Runs[0].Results) != 1 {
+		t.Errorf("expected 1 result, got %d", len(doc.Runs[0].Results))
+	}
+}

--- a/pkg/output/table_test.go
+++ b/pkg/output/table_test.go
@@ -1,0 +1,390 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/analysis"
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+// ---------- WriteStats ----------
+
+func TestTableWriter_WriteStats(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewTableWriter(&buf)
+
+	stats := graph.GraphStats{
+		TotalNodes: 8,
+		TotalEdges: 12,
+		NodeCounts: map[graph.NodeType]int{
+			graph.NodeWorkload:       2,
+			graph.NodeServiceAccount: 3,
+			graph.NodeRole:           3,
+		},
+		EdgeCounts: map[graph.EdgeType]int{
+			graph.EdgeUses:   2,
+			graph.EdgeBinds:  3,
+			graph.EdgeGrants: 7,
+		},
+	}
+
+	if err := w.WriteStats(stats); err != nil {
+		t.Fatalf("WriteStats error: %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{
+		"Graph Statistics",
+		"Total Nodes: 8",
+		"Total Edges: 12",
+		"Node Counts:",
+		"Edge Counts:",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+}
+
+// ---------- WriteGraph ----------
+
+func TestTableWriter_WriteGraph(t *testing.T) {
+	g := graph.New()
+	n1 := graph.NewNode(graph.NodeWorkload, "default", "app")
+	n1.Metadata.WorkloadKind = "Deployment"
+	n2 := graph.NewNode(graph.NodeServiceAccount, "default", "app-sa")
+	g.AddNode(n1)
+	g.AddNode(n2)
+	g.AddEdge(graph.NewEdge(graph.EdgeUses, n1.ID, n2.ID))
+
+	var buf bytes.Buffer
+	w := NewTableWriter(&buf)
+	if err := w.WriteGraph(g); err != nil {
+		t.Fatalf("WriteGraph error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Total Nodes: 2") {
+		t.Errorf("expected Total Nodes: 2, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Total Edges: 1") {
+		t.Errorf("expected Total Edges: 1, got:\n%s", out)
+	}
+}
+
+// ---------- WriteBlastResult ----------
+
+func TestTableWriter_WriteBlastResult(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewTableWriter(&buf)
+
+	r := sampleBlastResult()
+	if err := w.WriteBlastResult(r); err != nil {
+		t.Fatalf("WriteBlastResult error: %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{
+		"Blast Radius Analysis",
+		"nginx",
+		"nginx-sa",
+		"K8s Permissions: 3",
+		"Cloud Roles:     1",
+		"Kubernetes Resource Access",
+		"reader-role",
+		"Cloud Role Access",
+		"aws",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+}
+
+func TestTableWriter_WriteBlastResult_Nil(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewTableWriter(&buf)
+	if err := w.WriteBlastResult(nil); err != nil {
+		t.Fatalf("WriteBlastResult(nil) error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No results found") {
+		t.Error("expected 'No results found' for nil input")
+	}
+}
+
+func TestTableWriter_WriteBlastResult_NoK8sResources(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewTableWriter(&buf)
+
+	r := &analysis.BlastResult{
+		SourceWorkload: makeWorkloadNode("ns", "app", "Deployment"),
+		ServiceAccount: makeSANode("ns", "app-sa"),
+		TotalK8sPerms:  0,
+		MaxSeverity:    graph.SeverityLow,
+	}
+	if err := w.WriteBlastResult(r); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "Kubernetes Resource Access") {
+		t.Error("should not show K8s resource table when empty")
+	}
+}
+
+// ---------- WriteBlastResults ----------
+
+func TestTableWriter_WriteBlastResults(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewTableWriter(&buf)
+
+	results := []*analysis.BlastResult{sampleBlastResult()}
+	if err := w.WriteBlastResults(results); err != nil {
+		t.Fatalf("WriteBlastResults error: %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{
+		"Workload Blast Radius Summary",
+		"WORKLOAD",
+		"NAMESPACE",
+		"SERVICE ACCOUNT",
+		"Total: 1 workloads",
+		"Critical: 1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+}
+
+func TestTableWriter_WriteBlastResults_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewTableWriter(&buf)
+	if err := w.WriteBlastResults(nil); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No workloads found") {
+		t.Error("expected 'No workloads found'")
+	}
+}
+
+// ---------- WriteRBACAuditResult ----------
+
+func TestTableWriter_WriteRBACAuditResult(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewTableWriter(&buf)
+
+	result := &analysis.RBACAuditResult{
+		Findings: []analysis.RBACFinding{
+			{
+				CheckID:     "RBAC001",
+				Severity:    graph.SeverityCritical,
+				Title:       "Wildcard permissions",
+				Description: "SA has wildcard",
+				Affected: []analysis.AffectedResource{
+					{Namespace: "default", Name: "admin-sa", Details: "has *"},
+				},
+				Remediation: "Restrict verbs",
+			},
+		},
+		Summary: analysis.AuditSummary{
+			Critical: 1,
+		},
+		ChecksRun:     []string{"RBAC001"},
+		TotalFindings: 1,
+	}
+
+	if err := w.WriteRBACAuditResult(result); err != nil {
+		t.Fatalf("WriteRBACAuditResult error: %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{
+		"RBAC Security Audit",
+		"RBAC001",
+		"Wildcard permissions",
+		"Critical: 1",
+		"Remediation: Restrict verbs",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+}
+
+func TestTableWriter_WriteRBACAuditResult_NoFindings(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewTableWriter(&buf)
+
+	result := &analysis.RBACAuditResult{
+		ChecksRun:     []string{"RBAC001"},
+		TotalFindings: 0,
+	}
+
+	if err := w.WriteRBACAuditResult(result); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No security issues found") {
+		t.Error("expected 'No security issues found'")
+	}
+}
+
+// ---------- WritePodSecurityResult ----------
+
+func TestTableWriter_WritePodSecurityResult(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewTableWriter(&buf)
+
+	result := &analysis.PodSecurityResult{
+		Findings: []analysis.PodSecurityFinding{
+			{
+				CheckID:     "PSS001",
+				Severity:    graph.SeverityCritical,
+				Title:       "Privileged Containers",
+				Description: "Running privileged",
+				Affected: []analysis.AffectedWorkload{
+					{Kind: "Deployment", Namespace: "default", Name: "web", Container: "app", Details: "privileged: true"},
+				},
+				Remediation: "Remove privileged",
+			},
+		},
+		Summary: analysis.PodSecuritySummary{
+			Critical:   1,
+			ByCategory: map[string]int{"privilege_escalation": 1},
+		},
+		ChecksRun:    []string{"PSS001"},
+		TotalFindings: 1,
+	}
+
+	if err := w.WritePodSecurityResult(result); err != nil {
+		t.Fatalf("WritePodSecurityResult error: %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{
+		"Pod Security Audit",
+		"PSS001",
+		"Privileged Containers",
+		"Deployment default/web/app",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+}
+
+func TestTableWriter_WritePodSecurityResult_NoFindings(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewTableWriter(&buf)
+	result := &analysis.PodSecurityResult{
+		ChecksRun:    []string{"PSS001"},
+		TotalFindings: 0,
+	}
+	if err := w.WritePodSecurityResult(result); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No pod security issues found") {
+		t.Error("expected 'No pod security issues found'")
+	}
+}
+
+// ---------- WriteNetworkPolicyResult ----------
+
+func TestTableWriter_WriteNetworkPolicyResult(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewTableWriter(&buf)
+
+	result := &analysis.NetworkPolicyResult{
+		Findings: []analysis.NetworkPolicyFinding{
+			{
+				CheckID:     "NET001",
+				Severity:    graph.SeverityHigh,
+				Title:       "No Network Policy",
+				Description: "Workload has no policy",
+				Affected: []analysis.AffectedNetworkResource{
+					{Kind: "Deployment", Namespace: "default", Name: "web", Details: "no policy", Services: []string{"web-svc"}},
+				},
+				Remediation: "Create NetworkPolicy",
+			},
+		},
+		Summary: analysis.NetworkPolicySummary{
+			High:                   1,
+			TotalNetworkPolicies:   0,
+			WorkloadsWithoutPolicy: 1,
+			ByCategory:            map[string]int{"missing_policy": 1},
+		},
+		ChecksRun:    []string{"NET001"},
+		TotalFindings: 1,
+	}
+
+	if err := w.WriteNetworkPolicyResult(result); err != nil {
+		t.Fatalf("WriteNetworkPolicyResult error: %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{
+		"Network Policy Audit",
+		"NET001",
+		"No Network Policy",
+		"web-svc",
+		"Workloads without policy:     1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+}
+
+func TestTableWriter_WriteNetworkPolicyResult_NoFindings(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewTableWriter(&buf)
+	result := &analysis.NetworkPolicyResult{
+		ChecksRun:    []string{"NET001"},
+		TotalFindings: 0,
+		Summary: analysis.NetworkPolicySummary{
+			TotalNetworkPolicies: 5,
+		},
+	}
+	if err := w.WriteNetworkPolicyResult(result); err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No network policy issues found") {
+		t.Error("expected 'No network policy issues found'")
+	}
+}
+
+// ---------- severityColor ----------
+
+func TestSeverityColor(t *testing.T) {
+	tests := []struct {
+		severity graph.Severity
+		contains string
+	}{
+		{graph.SeverityCritical, "\033[31m"},
+		{graph.SeverityHigh, "\033[33m"},
+		{graph.SeverityMedium, "\033[36m"},
+		{graph.SeverityLow, "low"},
+	}
+	for _, tc := range tests {
+		got := severityColor(tc.severity)
+		if !strings.Contains(got, tc.contains) {
+			t.Errorf("severityColor(%q) = %q, want to contain %q", tc.severity, got, tc.contains)
+		}
+	}
+}
+
+// ---------- truncateString ----------
+
+func TestTruncateString(t *testing.T) {
+	if got := truncateString("short", 10); got != "short" {
+		t.Errorf("expected %q, got %q", "short", got)
+	}
+	if got := truncateString("a-very-long-string-here", 10); got != "a-very-l.." {
+		t.Errorf("expected %q, got %q", "a-very-l..", got)
+	}
+	if got := truncateString("exact", 5); got != "exact" {
+		t.Errorf("expected %q, got %q", "exact", got)
+	}
+}

--- a/pkg/remediation/generator_test.go
+++ b/pkg/remediation/generator_test.go
@@ -1,0 +1,187 @@
+package remediation
+
+import (
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/analysis"
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+func TestGenerateAllRemediations_MixedFindings(t *testing.T) {
+	rbac := []analysis.RBACFinding{
+		{
+			CheckID:     "RBAC001",
+			Severity:    graph.SeverityCritical,
+			Description: "Cluster-admin binding found",
+			Affected: []analysis.AffectedResource{
+				{Kind: "ClusterRoleBinding", Namespace: "cluster-wide", Name: "admin-binding"},
+			},
+		},
+	}
+	podSec := []analysis.PodSecurityFinding{
+		{
+			CheckID:     "PSS001",
+			Severity:    graph.SeverityCritical,
+			Description: "Privileged container",
+			Affected: []analysis.AffectedWorkload{
+				{Kind: "Deployment", Namespace: "default", Name: "web-app", Container: "nginx"},
+			},
+		},
+	}
+	netPol := []analysis.NetworkPolicyFinding{
+		{
+			CheckID:     "NET001",
+			Severity:    graph.SeverityHigh,
+			Description: "No network policy",
+			Affected: []analysis.AffectedNetworkResource{
+				{Kind: "Namespace", Namespace: "default", Name: "default"},
+			},
+		},
+	}
+
+	result := GenerateAllRemediations(rbac, podSec, netPol)
+
+	if result.TotalFindings != 3 {
+		t.Errorf("TotalFindings = %d, want 3", result.TotalFindings)
+	}
+	if result.RemediableCount == 0 {
+		t.Error("expected at least some remediable findings")
+	}
+	if result.CombinedManifests == "" {
+		t.Error("CombinedManifests should not be empty")
+	}
+
+	// Check that we have remediations from all three types
+	typesSeen := map[RemediationType]bool{}
+	for _, r := range result.Remediations {
+		typesSeen[r.Type] = true
+	}
+	if !typesSeen[RemediationRBAC] {
+		t.Error("expected RBAC remediations")
+	}
+	if !typesSeen[RemediationPodSecurity] {
+		t.Error("expected PodSecurity remediations")
+	}
+	if !typesSeen[RemediationNetworkPolicy] {
+		t.Error("expected NetworkPolicy remediations")
+	}
+}
+
+func TestGenerateAllRemediations_EmptyFindings(t *testing.T) {
+	result := GenerateAllRemediations(nil, nil, nil)
+
+	if result.TotalFindings != 0 {
+		t.Errorf("TotalFindings = %d, want 0", result.TotalFindings)
+	}
+	if result.RemediableCount != 0 {
+		t.Errorf("RemediableCount = %d, want 0", result.RemediableCount)
+	}
+	if len(result.Remediations) != 0 {
+		t.Errorf("expected no remediations, got %d", len(result.Remediations))
+	}
+}
+
+func TestFilterBySeverity(t *testing.T) {
+	result := &RemediationResult{
+		TotalFindings: 4,
+		Remediations: []Remediation{
+			{Type: RemediationRBAC, Severity: "critical", CheckID: "RBAC001", Manifests: []Manifest{{Action: "create", YAML: "a"}}},
+			{Type: RemediationRBAC, Severity: "high", CheckID: "RBAC003", Manifests: []Manifest{{Action: "create", YAML: "b"}}},
+			{Type: RemediationPodSecurity, Severity: "medium", CheckID: "PSS001", Manifests: []Manifest{{Action: "patch", YAML: "c"}}},
+			{Type: RemediationNetworkPolicy, Severity: "low", CheckID: "NET001", Manifests: []Manifest{{Action: "create", YAML: "d"}}},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		minSeverity string
+		wantCount   int
+	}{
+		{"filter critical only", "critical", 1},
+		{"filter high and above", "high", 2},
+		{"filter medium and above", "medium", 3},
+		{"filter low and above", "low", 4},
+		{"filter info (all)", "info", 4},
+		{"unknown severity defaults to medium", "unknown", 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered := FilterBySeverity(result, tt.minSeverity)
+			if filtered.RemediableCount != tt.wantCount {
+				t.Errorf("FilterBySeverity(%q) got %d remediations, want %d",
+					tt.minSeverity, filtered.RemediableCount, tt.wantCount)
+			}
+			if filtered.TotalFindings != result.TotalFindings {
+				t.Error("TotalFindings should be preserved from original")
+			}
+		})
+	}
+}
+
+func TestFilterByType(t *testing.T) {
+	result := &RemediationResult{
+		TotalFindings: 5,
+		Remediations: []Remediation{
+			{Type: RemediationRBAC, Severity: "high", Manifests: []Manifest{{Action: "create", YAML: "a"}}},
+			{Type: RemediationRBAC, Severity: "critical", Manifests: []Manifest{{Action: "create", YAML: "b"}}},
+			{Type: RemediationPodSecurity, Severity: "high", Manifests: []Manifest{{Action: "patch", YAML: "c"}}},
+			{Type: RemediationNetworkPolicy, Severity: "medium", Manifests: []Manifest{{Action: "create", YAML: "d"}}},
+			{Type: RemediationServiceAccount, Severity: "medium", Manifests: []Manifest{{Action: "patch", YAML: "e"}}},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		remType   RemediationType
+		wantCount int
+	}{
+		{"filter RBAC", RemediationRBAC, 2},
+		{"filter PodSecurity", RemediationPodSecurity, 1},
+		{"filter NetworkPolicy", RemediationNetworkPolicy, 1},
+		{"filter ServiceAccount", RemediationServiceAccount, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered := FilterByType(result, tt.remType)
+			if filtered.RemediableCount != tt.wantCount {
+				t.Errorf("FilterByType(%q) got %d, want %d",
+					tt.remType, filtered.RemediableCount, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestFilterByNamespace(t *testing.T) {
+	result := &RemediationResult{
+		TotalFindings:   3,
+		RemediableCount: 3,
+		Remediations: []Remediation{
+			{Type: RemediationRBAC, Resource: ResourceRef{Namespace: "default"}, Manifests: []Manifest{{Action: "create", YAML: "a"}}},
+			{Type: RemediationRBAC, Resource: ResourceRef{Namespace: "kube-system"}, Manifests: []Manifest{{Action: "create", YAML: "b"}}},
+			{Type: RemediationPodSecurity, Resource: ResourceRef{Namespace: "default"}, Manifests: []Manifest{{Action: "patch", YAML: "c"}}},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		namespace string
+		wantCount int
+	}{
+		{"filter default namespace", "default", 2},
+		{"filter kube-system", "kube-system", 1},
+		{"filter nonexistent namespace", "staging", 0},
+		{"empty namespace returns all", "", 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered := FilterByNamespace(result, tt.namespace)
+			if filtered.RemediableCount != tt.wantCount {
+				t.Errorf("FilterByNamespace(%q) got %d, want %d",
+					tt.namespace, filtered.RemediableCount, tt.wantCount)
+			}
+		})
+	}
+}

--- a/pkg/remediation/networkpolicy_test.go
+++ b/pkg/remediation/networkpolicy_test.go
@@ -1,0 +1,395 @@
+package remediation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/analysis"
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+func TestGenerateNetworkPolicyRemediations(t *testing.T) {
+	tests := []struct {
+		name          string
+		findings      []analysis.NetworkPolicyFinding
+		wantCount     int
+		wantAction    string
+		wantCheckID   string
+		checkManifest func(t *testing.T, rems []Remediation)
+	}{
+		{
+			name: "no network policy NET001",
+			findings: []analysis.NetworkPolicyFinding{
+				{
+					CheckID:     "NET001",
+					Severity:    graph.SeverityHigh,
+					Description: "No network policy in namespace",
+					Affected: []analysis.AffectedNetworkResource{
+						{Kind: "Namespace", Namespace: "default", Name: "default"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Create default-deny network policy",
+			wantCheckID: "NET001",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if len(rems[0].Manifests) != 2 {
+					t.Fatalf("expected 2 manifests (deny-all + dns), got %d", len(rems[0].Manifests))
+				}
+				if !strings.Contains(rems[0].Manifests[0].YAML, "default-deny-all") {
+					t.Error("first manifest should be default-deny-all")
+				}
+				if !strings.Contains(rems[0].Manifests[1].YAML, "allow-dns-egress") {
+					t.Error("second manifest should be allow-dns-egress")
+				}
+				if rems[0].Resource.Kind != "Namespace" {
+					t.Errorf("resource kind should be Namespace, got %s", rems[0].Resource.Kind)
+				}
+			},
+		},
+		{
+			name: "no default deny NET002",
+			findings: []analysis.NetworkPolicyFinding{
+				{
+					CheckID:     "NET002",
+					Severity:    graph.SeverityHigh,
+					Description: "No default deny policy",
+					Affected: []analysis.AffectedNetworkResource{
+						{Kind: "Namespace", Namespace: "production", Name: "production"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Add default-deny network policy",
+			wantCheckID: "NET002",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if len(rems[0].Manifests) != 1 {
+					t.Fatalf("expected 1 manifest, got %d", len(rems[0].Manifests))
+				}
+				if !strings.Contains(rems[0].Manifests[0].YAML, "default-deny-all") {
+					t.Error("should create default-deny-all policy")
+				}
+				if !strings.Contains(rems[0].Manifests[0].YAML, "namespace: production") {
+					t.Error("should reference production namespace")
+				}
+			},
+		},
+		{
+			name: "no ingress policy NET003",
+			findings: []analysis.NetworkPolicyFinding{
+				{
+					CheckID:  "NET003",
+					Severity: graph.SeverityMedium,
+					Affected: []analysis.AffectedNetworkResource{
+						{Kind: "Namespace", Namespace: "staging", Name: "staging"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Add default-deny ingress policy",
+			wantCheckID: "NET003",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "default-deny-ingress") {
+					t.Error("should create default-deny-ingress")
+				}
+			},
+		},
+		{
+			name: "no egress policy NET004",
+			findings: []analysis.NetworkPolicyFinding{
+				{
+					CheckID:  "NET004",
+					Severity: graph.SeverityMedium,
+					Affected: []analysis.AffectedNetworkResource{
+						{Kind: "Namespace", Namespace: "dev", Name: "dev"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Add default-deny egress policy",
+			wantCheckID: "NET004",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if len(rems[0].Manifests) != 2 {
+					t.Fatalf("expected 2 manifests (deny-egress + dns), got %d", len(rems[0].Manifests))
+				}
+				if !strings.Contains(rems[0].Manifests[0].YAML, "default-deny-egress") {
+					t.Error("first manifest should be default-deny-egress")
+				}
+				if !strings.Contains(rems[0].Manifests[1].YAML, "allow-dns-egress") {
+					t.Error("second manifest should allow DNS egress")
+				}
+			},
+		},
+		{
+			name: "allow all ingress NET005",
+			findings: []analysis.NetworkPolicyFinding{
+				{
+					CheckID:     "NET005",
+					Severity:    graph.SeverityHigh,
+					Description: "Allow-all ingress policy",
+					Affected: []analysis.AffectedNetworkResource{
+						{Kind: "NetworkPolicy", Namespace: "default", Name: "allow-all"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Restrict overly permissive ingress rules",
+			wantCheckID: "NET005",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				yaml := rems[0].Manifests[0].YAML
+				if !strings.Contains(yaml, "podSelector") {
+					t.Error("should suggest podSelector-based ingress")
+				}
+				if rems[0].Resource.Kind != "NetworkPolicy" {
+					t.Errorf("resource kind should be NetworkPolicy, got %s", rems[0].Resource.Kind)
+				}
+				if rems[0].Manifests[0].Action != "replace" {
+					t.Errorf("action should be replace, got %s", rems[0].Manifests[0].Action)
+				}
+			},
+		},
+		{
+			name: "allow all egress NET006",
+			findings: []analysis.NetworkPolicyFinding{
+				{
+					CheckID:     "NET006",
+					Severity:    graph.SeverityHigh,
+					Description: "Allow-all egress policy",
+					Affected: []analysis.AffectedNetworkResource{
+						{Kind: "NetworkPolicy", Namespace: "default", Name: "open-egress"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Restrict overly permissive egress rules",
+			wantCheckID: "NET006",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				yaml := rems[0].Manifests[0].YAML
+				if !strings.Contains(yaml, "port: 5432") {
+					t.Error("should suggest specific port restrictions")
+				}
+			},
+		},
+		{
+			name: "wide CIDR NET007",
+			findings: []analysis.NetworkPolicyFinding{
+				{
+					CheckID:     "NET007",
+					Severity:    graph.SeverityMedium,
+					Description: "Wide CIDR range",
+					Affected: []analysis.AffectedNetworkResource{
+						{Kind: "NetworkPolicy", Namespace: "default", Name: "wide-policy"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Replace wide CIDR with specific ranges",
+			wantCheckID: "NET007",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "0.0.0.0/0") {
+					t.Error("should reference 0.0.0.0/0 as the problem")
+				}
+			},
+		},
+		{
+			name: "all namespaces NET008",
+			findings: []analysis.NetworkPolicyFinding{
+				{
+					CheckID:     "NET008",
+					Severity:    graph.SeverityMedium,
+					Description: "All-namespace selector",
+					Affected: []analysis.AffectedNetworkResource{
+						{Kind: "NetworkPolicy", Namespace: "prod", Name: "ns-wide"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Restrict namespace selector to specific namespaces",
+			wantCheckID: "NET008",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "namespaceSelector") {
+					t.Error("should reference namespaceSelector")
+				}
+			},
+		},
+		{
+			name: "unknown check returns nil",
+			findings: []analysis.NetworkPolicyFinding{
+				{
+					CheckID:  "NET999",
+					Severity: graph.SeverityLow,
+					Affected: []analysis.AffectedNetworkResource{
+						{Kind: "NetworkPolicy", Namespace: "default", Name: "unknown"},
+					},
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name:      "empty findings",
+			findings:  nil,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rems := GenerateNetworkPolicyRemediations(tt.findings)
+
+			if len(rems) != tt.wantCount {
+				t.Fatalf("got %d remediations, want %d", len(rems), tt.wantCount)
+			}
+
+			if tt.wantCount == 0 {
+				return
+			}
+
+			r := rems[0]
+			if r.Type != RemediationNetworkPolicy {
+				t.Errorf("type = %q, want %q", r.Type, RemediationNetworkPolicy)
+			}
+			if tt.wantAction != "" && r.Action != tt.wantAction {
+				t.Errorf("action = %q, want %q", r.Action, tt.wantAction)
+			}
+			if tt.wantCheckID != "" && r.CheckID != tt.wantCheckID {
+				t.Errorf("checkID = %q, want %q", r.CheckID, tt.wantCheckID)
+			}
+			if len(r.Manifests) == 0 {
+				t.Error("expected at least one manifest")
+			}
+			for _, m := range r.Manifests {
+				if m.YAML == "" {
+					t.Error("manifest YAML should not be empty")
+				}
+			}
+
+			if tt.checkManifest != nil {
+				tt.checkManifest(t, rems)
+			}
+		})
+	}
+}
+
+func TestGenerateNetworkPolicyRemediations_DeduplicateByNamespace(t *testing.T) {
+	// NET001 and NET002 both use nsProcessed to deduplicate per namespace
+	findings := []analysis.NetworkPolicyFinding{
+		{
+			CheckID:  "NET001",
+			Severity: graph.SeverityHigh,
+			Affected: []analysis.AffectedNetworkResource{
+				{Kind: "Namespace", Namespace: "default", Name: "pod1"},
+				{Kind: "Namespace", Namespace: "default", Name: "pod2"},
+			},
+		},
+	}
+
+	rems := GenerateNetworkPolicyRemediations(findings)
+
+	// Should only get one remediation since both affected resources are in same namespace
+	if len(rems) != 1 {
+		t.Errorf("expected 1 remediation (deduplicated by namespace), got %d", len(rems))
+	}
+}
+
+func TestGenerateNetworkPolicyRemediations_DifferentNamespaces(t *testing.T) {
+	findings := []analysis.NetworkPolicyFinding{
+		{
+			CheckID:  "NET001",
+			Severity: graph.SeverityHigh,
+			Affected: []analysis.AffectedNetworkResource{
+				{Kind: "Namespace", Namespace: "ns1", Name: "ns1"},
+				{Kind: "Namespace", Namespace: "ns2", Name: "ns2"},
+			},
+		},
+	}
+
+	rems := GenerateNetworkPolicyRemediations(findings)
+
+	if len(rems) != 2 {
+		t.Errorf("expected 2 remediations (different namespaces), got %d", len(rems))
+	}
+}
+
+func TestGenerateNetworkPolicyRemediations_CrossFindingDedup(t *testing.T) {
+	// NET001 and NET002 share the same nsProcessed key pattern
+	// If NET001 already processed namespace "default", NET002 should skip it
+	findings := []analysis.NetworkPolicyFinding{
+		{
+			CheckID:  "NET001",
+			Severity: graph.SeverityHigh,
+			Affected: []analysis.AffectedNetworkResource{
+				{Kind: "Namespace", Namespace: "default", Name: "default"},
+			},
+		},
+		{
+			CheckID:  "NET002",
+			Severity: graph.SeverityHigh,
+			Affected: []analysis.AffectedNetworkResource{
+				{Kind: "Namespace", Namespace: "default", Name: "default"},
+			},
+		},
+	}
+
+	rems := GenerateNetworkPolicyRemediations(findings)
+
+	// Both NET001 and NET002 use the same "default-default-deny" key,
+	// so only one should produce a remediation
+	if len(rems) != 1 {
+		t.Errorf("expected 1 remediation (cross-finding dedup), got %d", len(rems))
+	}
+}
+
+func TestGenerateNetworkPolicyRemediations_NET003_Dedup(t *testing.T) {
+	findings := []analysis.NetworkPolicyFinding{
+		{
+			CheckID:  "NET003",
+			Severity: graph.SeverityMedium,
+			Affected: []analysis.AffectedNetworkResource{
+				{Kind: "Namespace", Namespace: "test", Name: "a"},
+				{Kind: "Namespace", Namespace: "test", Name: "b"},
+			},
+		},
+	}
+
+	rems := GenerateNetworkPolicyRemediations(findings)
+	if len(rems) != 1 {
+		t.Errorf("NET003 should dedup by namespace, got %d", len(rems))
+	}
+}
+
+func TestGenerateNetworkPolicyRemediations_NET004_Dedup(t *testing.T) {
+	findings := []analysis.NetworkPolicyFinding{
+		{
+			CheckID:  "NET004",
+			Severity: graph.SeverityMedium,
+			Affected: []analysis.AffectedNetworkResource{
+				{Kind: "Namespace", Namespace: "test", Name: "a"},
+				{Kind: "Namespace", Namespace: "test", Name: "b"},
+			},
+		},
+	}
+
+	rems := GenerateNetworkPolicyRemediations(findings)
+	if len(rems) != 1 {
+		t.Errorf("NET004 should dedup by namespace, got %d", len(rems))
+	}
+}
+
+func TestGenerateNetworkPolicyRemediations_MultipleAffectedNET005(t *testing.T) {
+	// NET005 does NOT deduplicate - each affected resource gets its own remediation
+	findings := []analysis.NetworkPolicyFinding{
+		{
+			CheckID:  "NET005",
+			Severity: graph.SeverityHigh,
+			Affected: []analysis.AffectedNetworkResource{
+				{Kind: "NetworkPolicy", Namespace: "default", Name: "policy1"},
+				{Kind: "NetworkPolicy", Namespace: "default", Name: "policy2"},
+			},
+		},
+	}
+
+	rems := GenerateNetworkPolicyRemediations(findings)
+	if len(rems) != 2 {
+		t.Errorf("NET005 should not dedup, expected 2 remediations, got %d", len(rems))
+	}
+}

--- a/pkg/remediation/podsecurity_test.go
+++ b/pkg/remediation/podsecurity_test.go
@@ -1,0 +1,473 @@
+package remediation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/analysis"
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+func TestGeneratePodSecurityRemediations(t *testing.T) {
+	tests := []struct {
+		name          string
+		findings      []analysis.PodSecurityFinding
+		wantCount     int
+		wantAction    string
+		wantCheckID   string
+		checkManifest func(t *testing.T, rems []Remediation)
+	}{
+		{
+			name: "privileged PSS001",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:     "PSS001",
+					Severity:    graph.SeverityCritical,
+					Description: "Privileged container",
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "web", Container: "nginx"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Remove privileged flag from container",
+			wantCheckID: "PSS001",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				yaml := rems[0].Manifests[0].YAML
+				if !strings.Contains(yaml, "privileged: false") {
+					t.Error("should set privileged: false")
+				}
+				if !strings.Contains(yaml, "name: nginx") {
+					t.Error("should reference correct container")
+				}
+				if !strings.Contains(yaml, "apiVersion: apps/v1") {
+					t.Error("Deployment should use apps/v1")
+				}
+			},
+		},
+		{
+			name: "privileged PSS001 no container defaults to app",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS001",
+					Severity: graph.SeverityCritical,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "web", Container: ""},
+					},
+				},
+			},
+			wantCount: 1,
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "name: app") {
+					t.Error("empty container should default to 'app'")
+				}
+			},
+		},
+		{
+			name: "hostNetwork PSS002",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:     "PSS002",
+					Severity:    graph.SeverityHigh,
+					Description: "hostNetwork enabled",
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "DaemonSet", Namespace: "monitoring", Name: "agent"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Disable hostNetwork",
+			wantCheckID: "PSS002",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "hostNetwork: false") {
+					t.Error("should mention hostNetwork: false")
+				}
+			},
+		},
+		{
+			name: "hostPID PSS003",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS003",
+					Severity: graph.SeverityHigh,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "debug-pod"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Disable hostPID",
+			wantCheckID: "PSS003",
+		},
+		{
+			name: "hostIPC PSS004",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS004",
+					Severity: graph.SeverityHigh,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "ipc-pod"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Disable hostIPC",
+			wantCheckID: "PSS004",
+		},
+		{
+			name: "hostPath PSS005",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS005",
+					Severity: graph.SeverityHigh,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "DaemonSet", Namespace: "logging", Name: "filebeat"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Replace hostPath volumes with safer alternatives",
+			wantCheckID: "PSS005",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "emptyDir") {
+					t.Error("should suggest emptyDir alternative")
+				}
+			},
+		},
+		{
+			name: "capabilities PSS006",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS006",
+					Severity: graph.SeverityHigh,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "caps-app", Container: "main"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Drop dangerous capabilities",
+			wantCheckID: "PSS006",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				yaml := rems[0].Manifests[0].YAML
+				if !strings.Contains(yaml, "drop:\n            - ALL") {
+					t.Error("should drop ALL capabilities")
+				}
+			},
+		},
+		{
+			name: "capabilities PSS015 and PSS016",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS015",
+					Severity: graph.SeverityHigh,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "a"},
+					},
+				},
+				{
+					CheckID:  "PSS016",
+					Severity: graph.SeverityHigh,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "b"},
+					},
+				},
+			},
+			wantCount: 2,
+		},
+		{
+			name: "privilege escalation PSS007",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS007",
+					Severity: graph.SeverityHigh,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "esc-app", Container: "svc"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Disable allowPrivilegeEscalation",
+			wantCheckID: "PSS007",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "allowPrivilegeEscalation: false") {
+					t.Error("should set allowPrivilegeEscalation: false")
+				}
+			},
+		},
+		{
+			name: "runAsRoot PSS008",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS008",
+					Severity: graph.SeverityHigh,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "StatefulSet", Namespace: "db", Name: "postgres", Container: "pg"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Configure non-root execution",
+			wantCheckID: "PSS008",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				yaml := rems[0].Manifests[0].YAML
+				if !strings.Contains(yaml, "runAsNonRoot: true") {
+					t.Error("should set runAsNonRoot: true")
+				}
+				if !strings.Contains(yaml, "runAsUser: 1000") {
+					t.Error("should set runAsUser: 1000")
+				}
+				if !strings.Contains(yaml, "apiVersion: apps/v1") {
+					t.Error("StatefulSet should use apps/v1")
+				}
+			},
+		},
+		{
+			name: "runAsRoot PSS009",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS009",
+					Severity: graph.SeverityHigh,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "root-app"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Configure non-root execution",
+			wantCheckID: "PSS009",
+		},
+		{
+			name: "seccomp PSS010",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS010",
+					Severity: graph.SeverityMedium,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "no-seccomp"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Enable seccomp profile",
+			wantCheckID: "PSS010",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "RuntimeDefault") {
+					t.Error("should set RuntimeDefault seccomp profile")
+				}
+			},
+		},
+		{
+			name: "seccomp PSS011",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS011",
+					Severity: graph.SeverityMedium,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "bad-seccomp"},
+					},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "security context PSS012",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS012",
+					Severity: graph.SeverityMedium,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "no-ctx", Container: "web"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Add security context",
+			wantCheckID: "PSS012",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				yaml := rems[0].Manifests[0].YAML
+				if !strings.Contains(yaml, "readOnlyRootFilesystem: true") {
+					t.Error("should set readOnlyRootFilesystem")
+				}
+				if !strings.Contains(yaml, "runAsNonRoot: true") {
+					t.Error("should set runAsNonRoot")
+				}
+			},
+		},
+		{
+			name: "security context PSS013",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS013",
+					Severity: graph.SeverityMedium,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "no-ctx2"},
+					},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "host ports PSS014",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS014",
+					Severity: graph.SeverityMedium,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "port-app"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Remove hostPort usage",
+			wantCheckID: "PSS014",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "kind: Service") {
+					t.Error("should suggest Service as alternative")
+				}
+			},
+		},
+		{
+			name: "windows host process PSS017",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS017",
+					Severity: graph.SeverityCritical,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "windows", Name: "win-app"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantAction:  "Disable Windows HostProcess",
+			wantCheckID: "PSS017",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "hostProcess: false") {
+					t.Error("should set hostProcess: false")
+				}
+			},
+		},
+		{
+			name: "unknown check returns nil",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS999",
+					Severity: graph.SeverityLow,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "default", Name: "unknown"},
+					},
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name:      "empty findings",
+			findings:  nil,
+			wantCount: 0,
+		},
+		{
+			name: "multiple affected workloads",
+			findings: []analysis.PodSecurityFinding{
+				{
+					CheckID:  "PSS001",
+					Severity: graph.SeverityCritical,
+					Affected: []analysis.AffectedWorkload{
+						{Kind: "Deployment", Namespace: "ns1", Name: "app1", Container: "c1"},
+						{Kind: "Deployment", Namespace: "ns2", Name: "app2", Container: "c2"},
+					},
+				},
+			},
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rems := GeneratePodSecurityRemediations(tt.findings)
+
+			if len(rems) != tt.wantCount {
+				t.Fatalf("got %d remediations, want %d", len(rems), tt.wantCount)
+			}
+
+			if tt.wantCount == 0 {
+				return
+			}
+
+			r := rems[0]
+			if r.Type != RemediationPodSecurity {
+				t.Errorf("type = %q, want %q", r.Type, RemediationPodSecurity)
+			}
+			if tt.wantAction != "" && r.Action != tt.wantAction {
+				t.Errorf("action = %q, want %q", r.Action, tt.wantAction)
+			}
+			if tt.wantCheckID != "" && r.CheckID != tt.wantCheckID {
+				t.Errorf("checkID = %q, want %q", r.CheckID, tt.wantCheckID)
+			}
+			if len(r.Manifests) == 0 {
+				t.Error("expected at least one manifest")
+			}
+			for _, m := range r.Manifests {
+				if m.YAML == "" {
+					t.Error("manifest YAML should not be empty")
+				}
+			}
+
+			if tt.checkManifest != nil {
+				tt.checkManifest(t, rems)
+			}
+		})
+	}
+}
+
+func TestParseContainerList(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"empty string returns app", "", []string{"app"}},
+		{"single container", "nginx", []string{"nginx"}},
+		{"multiple containers", "nginx, sidecar, init", []string{"nginx", "sidecar", "init"}},
+		{"whitespace only entries filtered", "nginx,  , sidecar", []string{"nginx", "sidecar"}},
+		{"all whitespace returns app", " , , ", []string{"app"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseContainerList(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseContainerList(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i, v := range got {
+				if v != tt.want[i] {
+					t.Errorf("parseContainerList(%q)[%d] = %q, want %q", tt.input, i, v, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestGetAPIVersion(t *testing.T) {
+	tests := []struct {
+		kind string
+		want string
+	}{
+		{"Deployment", "apps/v1"},
+		{"ReplicaSet", "apps/v1"},
+		{"StatefulSet", "apps/v1"},
+		{"DaemonSet", "apps/v1"},
+		{"Job", "batch/v1"},
+		{"CronJob", "batch/v1"},
+		{"Pod", "v1"},
+		{"Unknown", "apps/v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			got := getAPIVersion(tt.kind)
+			if got != tt.want {
+				t.Errorf("getAPIVersion(%q) = %q, want %q", tt.kind, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/remediation/rbac_test.go
+++ b/pkg/remediation/rbac_test.go
@@ -1,0 +1,415 @@
+package remediation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/analysis"
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+func TestGenerateRBACRemediations(t *testing.T) {
+	tests := []struct {
+		name          string
+		findings      []analysis.RBACFinding
+		wantCount     int
+		wantType      RemediationType
+		wantAction    string
+		wantCheckID   string
+		checkManifest func(t *testing.T, rems []Remediation)
+	}{
+		{
+			name: "cluster-admin RBAC001 cluster-wide",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:     "RBAC001",
+					Severity:    graph.SeverityCritical,
+					Description: "Cluster-admin role binding detected",
+					Affected: []analysis.AffectedResource{
+						{Kind: "ClusterRoleBinding", Namespace: "cluster-wide", Name: "admin-binding"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantType:    RemediationRBAC,
+			wantAction:  "Replace cluster-admin with least-privilege role",
+			wantCheckID: "RBAC001",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if len(rems[0].Manifests) != 2 {
+					t.Errorf("expected 2 manifests, got %d", len(rems[0].Manifests))
+				}
+				if !strings.Contains(rems[0].Manifests[0].YAML, "ClusterRole") {
+					t.Error("cluster-wide should generate ClusterRole")
+				}
+			},
+		},
+		{
+			name: "cluster-admin RBAC002 namespaced",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:     "RBAC002",
+					Severity:    graph.SeverityCritical,
+					Description: "Namespaced admin binding",
+					Affected: []analysis.AffectedResource{
+						{Kind: "RoleBinding", Namespace: "production", Name: "ns-admin"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantType:    RemediationRBAC,
+			wantAction:  "Replace cluster-admin with least-privilege role",
+			wantCheckID: "RBAC002",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "kind: Role") {
+					t.Error("namespaced finding should generate Role, not ClusterRole")
+				}
+				if !strings.Contains(rems[0].Manifests[0].YAML, "namespace: production") {
+					t.Error("should reference correct namespace")
+				}
+			},
+		},
+		{
+			name: "secrets access RBAC003",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:     "RBAC003",
+					Severity:    graph.SeverityHigh,
+					Description: "Role grants secrets access",
+					Affected: []analysis.AffectedResource{
+						{Kind: "ClusterRole", Namespace: "", Name: "secret-reader"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantType:    RemediationRBAC,
+			wantAction:  "Remove secrets access from role",
+			wantCheckID: "RBAC003",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "secret-reader-no-secrets") {
+					t.Error("should create role with -no-secrets suffix")
+				}
+				if !strings.Contains(rems[0].Manifests[0].YAML, "ClusterRole") {
+					t.Error("empty namespace should generate ClusterRole")
+				}
+			},
+		},
+		{
+			name: "secrets access RBAC012 namespaced",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:     "RBAC012",
+					Severity:    graph.SeverityHigh,
+					Description: "Role grants secrets access",
+					Affected: []analysis.AffectedResource{
+						{Kind: "Role", Namespace: "dev", Name: "dev-role"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantType:    RemediationRBAC,
+			wantAction:  "Remove secrets access from role",
+			wantCheckID: "RBAC012",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "kind: Role") {
+					t.Error("namespaced role should generate Role")
+				}
+				if !strings.Contains(rems[0].Manifests[0].YAML, "namespace: dev") {
+					t.Error("should reference dev namespace")
+				}
+			},
+		},
+		{
+			name: "wildcard permissions RBAC004",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:     "RBAC004",
+					Severity:    graph.SeverityHigh,
+					Description: "Wildcard permissions detected",
+					Affected: []analysis.AffectedResource{
+						{Kind: "ClusterRole", Namespace: "", Name: "wildcard-role"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantType:    RemediationRBAC,
+			wantAction:  "Replace wildcards with explicit permissions",
+			wantCheckID: "RBAC004",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "wildcard-role-explicit") {
+					t.Error("should create role with -explicit suffix")
+				}
+			},
+		},
+		{
+			name: "default service account RBAC005",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:     "RBAC005",
+					Severity:    graph.SeverityMedium,
+					Description: "Default SA used for workload",
+					Affected: []analysis.AffectedResource{
+						{Kind: "ServiceAccount", Namespace: "production", Name: "default"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantType:    RemediationRBAC,
+			wantAction:  "Create dedicated service account for workload",
+			wantCheckID: "RBAC005",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "app-service-account") {
+					t.Error("should create app-service-account")
+				}
+				if !strings.Contains(rems[0].Manifests[0].YAML, "automountServiceAccountToken: false") {
+					t.Error("should disable automount token")
+				}
+			},
+		},
+		{
+			name: "default SA with empty namespace defaults to default",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:     "RBAC005",
+					Severity:    graph.SeverityMedium,
+					Description: "Default SA",
+					Affected: []analysis.AffectedResource{
+						{Kind: "ServiceAccount", Namespace: "", Name: "default"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantType:    RemediationRBAC,
+			wantAction:  "Create dedicated service account for workload",
+			wantCheckID: "RBAC005",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if rems[0].Resource.Namespace != "default" {
+					t.Errorf("empty namespace should default to 'default', got %q", rems[0].Resource.Namespace)
+				}
+			},
+		},
+		{
+			name: "automount token RBAC006",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:     "RBAC006",
+					Severity:    graph.SeverityMedium,
+					Description: "Token automount enabled",
+					Affected: []analysis.AffectedResource{
+						{Kind: "ServiceAccount", Namespace: "kube-system", Name: "monitoring-sa"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantType:    RemediationServiceAccount,
+			wantAction:  "Disable automatic token mounting",
+			wantCheckID: "RBAC006",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "automountServiceAccountToken: false") {
+					t.Error("should disable automount")
+				}
+				if rems[0].Manifests[0].Action != "patch" {
+					t.Errorf("action should be patch, got %s", rems[0].Manifests[0].Action)
+				}
+			},
+		},
+		{
+			name: "pod create access RBAC007",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:     "RBAC007",
+					Severity:    graph.SeverityHigh,
+					Description: "Pod create permissions",
+					Affected: []analysis.AffectedResource{
+						{Kind: "ClusterRole", Namespace: "", Name: "deployer"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantType:    RemediationRBAC,
+			wantAction:  "Remove pod creation permissions",
+			wantCheckID: "RBAC007",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if !strings.Contains(rems[0].Manifests[0].YAML, "deployer-no-pod-create") {
+					t.Error("should create role with -no-pod-create suffix")
+				}
+			},
+		},
+		{
+			name: "escalation permissions RBAC008",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:     "RBAC008",
+					Severity:    graph.SeverityCritical,
+					Description: "Bind verb on roles",
+					Affected: []analysis.AffectedResource{
+						{Kind: "ClusterRole", Namespace: "", Name: "escalator"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantType:    RemediationRBAC,
+			wantAction:  "Remove escalation permissions (bind/escalate/impersonate)",
+			wantCheckID: "RBAC008",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if rems[0].Manifests[0].Action != "review" {
+					t.Errorf("expected review action, got %s", rems[0].Manifests[0].Action)
+				}
+			},
+		},
+		{
+			name: "escalation RBAC009",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:  "RBAC009",
+					Severity: graph.SeverityCritical,
+					Affected: []analysis.AffectedResource{
+						{Kind: "ClusterRole", Name: "esc-role"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantCheckID: "RBAC009",
+		},
+		{
+			name: "escalation RBAC010",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:  "RBAC010",
+					Severity: graph.SeverityCritical,
+					Affected: []analysis.AffectedResource{
+						{Kind: "ClusterRole", Name: "imp-role"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantCheckID: "RBAC010",
+		},
+		{
+			name: "node access RBAC011",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:     "RBAC011",
+					Severity:    graph.SeverityHigh,
+					Description: "Node access detected",
+					Affected: []analysis.AffectedResource{
+						{Kind: "ClusterRole", Namespace: "", Name: "node-manager"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantType:    RemediationRBAC,
+			wantAction:  "Restrict node access permissions",
+			wantCheckID: "RBAC011",
+			checkManifest: func(t *testing.T, rems []Remediation) {
+				if rems[0].Manifests[0].Action != "review" {
+					t.Errorf("expected review action, got %s", rems[0].Manifests[0].Action)
+				}
+			},
+		},
+		{
+			name: "escalation RBAC013 and RBAC014",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:  "RBAC013",
+					Severity: graph.SeverityCritical,
+					Affected: []analysis.AffectedResource{
+						{Kind: "ClusterRole", Name: "esc13"},
+					},
+				},
+				{
+					CheckID:  "RBAC014",
+					Severity: graph.SeverityCritical,
+					Affected: []analysis.AffectedResource{
+						{Kind: "ClusterRole", Name: "esc14"},
+					},
+				},
+			},
+			wantCount:   2,
+			wantCheckID: "RBAC013",
+		},
+		{
+			name: "wildcard RBAC015",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:  "RBAC015",
+					Severity: graph.SeverityHigh,
+					Affected: []analysis.AffectedResource{
+						{Kind: "Role", Namespace: "prod", Name: "wide-role"},
+					},
+				},
+			},
+			wantCount:   1,
+			wantCheckID: "RBAC015",
+			wantAction:  "Replace wildcards with explicit permissions",
+		},
+		{
+			name: "unknown check returns nil",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:  "RBAC999",
+					Severity: graph.SeverityLow,
+					Affected: []analysis.AffectedResource{
+						{Kind: "Role", Namespace: "test", Name: "unknown"},
+					},
+				},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "multiple affected resources",
+			findings: []analysis.RBACFinding{
+				{
+					CheckID:  "RBAC001",
+					Severity: graph.SeverityCritical,
+					Affected: []analysis.AffectedResource{
+						{Kind: "ClusterRoleBinding", Namespace: "cluster-wide", Name: "binding1"},
+						{Kind: "ClusterRoleBinding", Namespace: "cluster-wide", Name: "binding2"},
+					},
+				},
+			},
+			wantCount: 2,
+		},
+		{
+			name:      "empty findings",
+			findings:  nil,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rems := GenerateRBACRemediations(tt.findings)
+
+			if len(rems) != tt.wantCount {
+				t.Fatalf("got %d remediations, want %d", len(rems), tt.wantCount)
+			}
+
+			if tt.wantCount == 0 {
+				return
+			}
+
+			r := rems[0]
+			if tt.wantType != "" && r.Type != tt.wantType {
+				t.Errorf("type = %q, want %q", r.Type, tt.wantType)
+			}
+			if tt.wantAction != "" && r.Action != tt.wantAction {
+				t.Errorf("action = %q, want %q", r.Action, tt.wantAction)
+			}
+			if tt.wantCheckID != "" && r.CheckID != tt.wantCheckID {
+				t.Errorf("checkID = %q, want %q", r.CheckID, tt.wantCheckID)
+			}
+			if len(r.Manifests) == 0 {
+				t.Error("expected at least one manifest")
+			}
+			for _, m := range r.Manifests {
+				if m.YAML == "" {
+					t.Error("manifest YAML should not be empty")
+				}
+			}
+
+			if tt.checkManifest != nil {
+				tt.checkManifest(t, rems)
+			}
+		})
+	}
+}

--- a/pkg/remediation/remediation_test.go
+++ b/pkg/remediation/remediation_test.go
@@ -1,0 +1,163 @@
+package remediation
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRemediation_ToYAML_SingleManifest(t *testing.T) {
+	r := Remediation{
+		Manifests: []Manifest{
+			{Action: "create", Description: "Create role", YAML: "apiVersion: v1\nkind: Role"},
+		},
+	}
+
+	got, err := r.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "apiVersion: v1") {
+		t.Errorf("expected YAML to contain apiVersion, got: %s", got)
+	}
+	if strings.Contains(got, "---") {
+		t.Errorf("single manifest should not contain separator")
+	}
+}
+
+func TestRemediation_ToYAML_MultipleManifests(t *testing.T) {
+	r := Remediation{
+		Manifests: []Manifest{
+			{Action: "create", Description: "First", YAML: "kind: Role"},
+			{Action: "create", Description: "Second", YAML: "kind: ClusterRole"},
+		},
+	}
+
+	got, err := r.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "---\n") {
+		t.Errorf("multiple manifests should contain separator")
+	}
+	if !strings.Contains(got, "kind: Role") {
+		t.Errorf("should contain first manifest")
+	}
+	if !strings.Contains(got, "kind: ClusterRole") {
+		t.Errorf("should contain second manifest")
+	}
+}
+
+func TestRemediation_ToYAML_Empty(t *testing.T) {
+	r := Remediation{}
+	got, err := r.ToYAML()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string for no manifests, got: %q", got)
+	}
+}
+
+func TestRemediationResult_GenerateCombinedManifests(t *testing.T) {
+	rr := &RemediationResult{
+		Remediations: []Remediation{
+			{
+				CheckID: "RBAC001",
+				Manifests: []Manifest{
+					{Action: "create", Description: "Create role", YAML: "kind: Role\nname: test"},
+				},
+			},
+			{
+				CheckID: "PSS001",
+				Manifests: []Manifest{
+					{Action: "patch", Description: "Patch deployment", YAML: "kind: Deployment\nname: app"},
+				},
+			},
+		},
+	}
+
+	combined := rr.GenerateCombinedManifests()
+
+	if combined == "" {
+		t.Fatal("combined manifests should not be empty")
+	}
+	if !strings.Contains(combined, "# RBAC001: Create role") {
+		t.Error("should contain RBAC001 comment header")
+	}
+	if !strings.Contains(combined, "# PSS001: Patch deployment") {
+		t.Error("should contain PSS001 comment header")
+	}
+	if !strings.Contains(combined, "---\n") {
+		t.Error("should contain separator between manifests")
+	}
+	if rr.CombinedManifests != combined {
+		t.Error("CombinedManifests field should be set")
+	}
+}
+
+func TestRemediationResult_GenerateCombinedManifests_Dedup(t *testing.T) {
+	yaml := "kind: Role\nname: shared"
+	rr := &RemediationResult{
+		Remediations: []Remediation{
+			{
+				CheckID: "RBAC001",
+				Manifests: []Manifest{
+					{Action: "create", Description: "Create role", YAML: yaml},
+				},
+			},
+			{
+				CheckID: "RBAC002",
+				Manifests: []Manifest{
+					{Action: "create", Description: "Create role", YAML: yaml},
+				},
+			},
+		},
+	}
+
+	combined := rr.GenerateCombinedManifests()
+	count := strings.Count(combined, yaml)
+	if count != 1 {
+		t.Errorf("duplicate YAML should be deduplicated, found %d occurrences", count)
+	}
+}
+
+func TestRemediationResult_GenerateCombinedManifests_Empty(t *testing.T) {
+	rr := &RemediationResult{}
+	combined := rr.GenerateCombinedManifests()
+	if combined != "" {
+		t.Errorf("expected empty combined manifests, got: %q", combined)
+	}
+}
+
+func TestToYAMLString(t *testing.T) {
+	tests := []struct {
+		name  string
+		input interface{}
+		want  string
+	}{
+		{
+			name:  "simple map",
+			input: map[string]string{"key": "value"},
+			want:  "key: value",
+		},
+		{
+			name:  "struct",
+			input: ResourceRef{Kind: "Pod", Name: "test", Namespace: "default"},
+			want:  "kind: Pod",
+		},
+		{
+			name:  "nil",
+			input: nil,
+			want:  "null",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toYAMLString(tt.input)
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("toYAMLString() = %q, want to contain %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/watch/metrics_test.go
+++ b/pkg/watch/metrics_test.go
@@ -1,0 +1,211 @@
+package watch
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nelssec/identity-chain/pkg/analysis"
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+func TestNewMetrics(t *testing.T) {
+	m := NewMetrics()
+	if m == nil {
+		t.Fatal("NewMetrics returned nil")
+	}
+	// state should be nil initially
+	m.mu.RLock()
+	if m.state != nil {
+		t.Error("expected nil state on new Metrics")
+	}
+	m.mu.RUnlock()
+}
+
+func TestMetricsUpdate(t *testing.T) {
+	m := NewMetrics()
+	state := &WatchState{
+		Timestamp: time.Now(),
+		Summary: StateSummary{
+			CriticalCount: 2,
+			HighCount:     3,
+			MediumCount:   5,
+			LowCount:      10,
+			WorkloadCount: 8,
+			SACount:       4,
+			RoleCount:     6,
+		},
+	}
+	m.Update(state)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.state != state {
+		t.Error("Update did not set state")
+	}
+}
+
+func TestMetricsHandlerNilState(t *testing.T) {
+	m := NewMetrics()
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	rec := httptest.NewRecorder()
+	m.handler(rec, req)
+
+	resp := rec.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if ct != "text/plain; version=0.0.4" {
+		t.Errorf("unexpected content type: %s", ct)
+	}
+
+	body := rec.Body.String()
+
+	// With nil state, all counts should be 0
+	expectedLines := []string{
+		`idc_findings_total{severity="critical"} 0`,
+		`idc_findings_total{severity="high"} 0`,
+		`idc_findings_total{severity="medium"} 0`,
+		`idc_findings_total{severity="low"} 0`,
+		`idc_resources_total{type="workload"} 0`,
+		`idc_resources_total{type="serviceaccount"} 0`,
+		`idc_resources_total{type="role"} 0`,
+		`idc_last_analysis_timestamp_seconds 0`,
+	}
+	for _, line := range expectedLines {
+		if !strings.Contains(body, line) {
+			t.Errorf("missing expected line in output: %q", line)
+		}
+	}
+
+	// HELP and TYPE lines should be present
+	helpLines := []string{
+		"# HELP idc_findings_total",
+		"# TYPE idc_findings_total gauge",
+		"# HELP idc_resources_total",
+		"# TYPE idc_resources_total gauge",
+		"# HELP idc_last_analysis_timestamp_seconds",
+		"# TYPE idc_last_analysis_timestamp_seconds gauge",
+		"# HELP idc_rbac_findings_total",
+		"# TYPE idc_rbac_findings_total gauge",
+		"# HELP idc_pod_security_findings_total",
+		"# TYPE idc_pod_security_findings_total gauge",
+		"# HELP idc_network_policy_findings_total",
+		"# TYPE idc_network_policy_findings_total gauge",
+	}
+	for _, line := range helpLines {
+		if !strings.Contains(body, line) {
+			t.Errorf("missing expected line: %q", line)
+		}
+	}
+}
+
+func TestMetricsHandlerWithState(t *testing.T) {
+	m := NewMetrics()
+	ts := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+	state := &WatchState{
+		Timestamp: ts,
+		Summary: StateSummary{
+			CriticalCount: 1,
+			HighCount:     2,
+			MediumCount:   3,
+			LowCount:      4,
+			WorkloadCount: 10,
+			SACount:       5,
+			RoleCount:     7,
+		},
+		RBACFindings: []analysis.RBACFinding{
+			{CheckID: "RBAC001", Severity: graph.SeverityCritical},
+			{CheckID: "RBAC001", Severity: graph.SeverityCritical},
+			{CheckID: "RBAC002", Severity: graph.SeverityHigh},
+		},
+		PodSecFindings: []analysis.PodSecurityFinding{
+			{CheckID: "PSS001", Severity: graph.SeverityMedium},
+		},
+		NetPolFindings: []analysis.NetworkPolicyFinding{
+			{CheckID: "NET001", Severity: graph.SeverityLow},
+			{CheckID: "NET001", Severity: graph.SeverityLow},
+		},
+	}
+	m.Update(state)
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	rec := httptest.NewRecorder()
+	m.handler(rec, req)
+
+	body := rec.Body.String()
+
+	// Check severity counts
+	expectedLines := []string{
+		`idc_findings_total{severity="critical"} 1`,
+		`idc_findings_total{severity="high"} 2`,
+		`idc_findings_total{severity="medium"} 3`,
+		`idc_findings_total{severity="low"} 4`,
+		`idc_resources_total{type="workload"} 10`,
+		`idc_resources_total{type="serviceaccount"} 5`,
+		`idc_resources_total{type="role"} 7`,
+	}
+	for _, line := range expectedLines {
+		if !strings.Contains(body, line) {
+			t.Errorf("missing expected line: %q\nbody: %s", line, body)
+		}
+	}
+
+	// Check timestamp
+	expectedTS := ts.Unix()
+	tsLine := "idc_last_analysis_timestamp_seconds"
+	if !strings.Contains(body, tsLine) {
+		t.Errorf("missing timestamp metric")
+	}
+	_ = expectedTS // verified via the line presence
+
+	// Check RBAC per-check counts
+	if !strings.Contains(body, `idc_rbac_findings_total{check_id="RBAC001"} 2`) {
+		t.Error("missing RBAC001 count of 2")
+	}
+	if !strings.Contains(body, `idc_rbac_findings_total{check_id="RBAC002"} 1`) {
+		t.Error("missing RBAC002 count of 1")
+	}
+
+	// Check pod security per-check counts
+	if !strings.Contains(body, `idc_pod_security_findings_total{check_id="PSS001"} 1`) {
+		t.Error("missing PSS001 count")
+	}
+
+	// Check network policy per-check counts
+	if !strings.Contains(body, `idc_network_policy_findings_total{check_id="NET001"} 2`) {
+		t.Error("missing NET001 count of 2")
+	}
+}
+
+func TestMetricsReadyzNilState(t *testing.T) {
+	m := NewMetrics()
+
+	// We can't easily test the registered HTTP handlers since Serve uses
+	// the default mux. Instead, test the readyz logic directly.
+	m.mu.RLock()
+	hasState := m.state != nil
+	m.mu.RUnlock()
+
+	if hasState {
+		t.Error("expected no state initially")
+	}
+}
+
+func TestMetricsReadyzWithState(t *testing.T) {
+	m := NewMetrics()
+	m.Update(&WatchState{Timestamp: time.Now()})
+
+	m.mu.RLock()
+	hasState := m.state != nil
+	m.mu.RUnlock()
+
+	if !hasState {
+		t.Error("expected state to be set after Update")
+	}
+}

--- a/pkg/watch/watcher_test.go
+++ b/pkg/watch/watcher_test.go
@@ -1,0 +1,459 @@
+package watch
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nelssec/identity-chain/pkg/analysis"
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+func TestNewDebouncer(t *testing.T) {
+	called := make(chan struct{}, 1)
+	d := newDebouncer(50*time.Millisecond, func() {
+		called <- struct{}{}
+	})
+
+	if d == nil {
+		t.Fatal("newDebouncer returned nil")
+	}
+	if d.period != 50*time.Millisecond {
+		t.Errorf("expected period 50ms, got %v", d.period)
+	}
+	if d.callback == nil {
+		t.Error("callback should not be nil")
+	}
+}
+
+func TestDebouncerTriggerCallsCallback(t *testing.T) {
+	var count atomic.Int32
+	done := make(chan struct{}, 1)
+
+	d := newDebouncer(50*time.Millisecond, func() {
+		count.Add(1)
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	})
+
+	d.trigger()
+
+	select {
+	case <-done:
+		// callback was called
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("callback was not called within timeout")
+	}
+
+	if got := count.Load(); got != 1 {
+		t.Errorf("expected callback called once, got %d", got)
+	}
+}
+
+func TestDebouncerResetOnMultipleTriggers(t *testing.T) {
+	var count atomic.Int32
+	done := make(chan struct{}, 10)
+
+	d := newDebouncer(100*time.Millisecond, func() {
+		count.Add(1)
+		done <- struct{}{}
+	})
+
+	// Trigger rapidly -- the debouncer should reset each time, so only
+	// the last trigger's timer fires.
+	for i := 0; i < 5; i++ {
+		d.trigger()
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("callback was not called within timeout")
+	}
+
+	// Allow a small window for any extra calls
+	time.Sleep(150 * time.Millisecond)
+
+	if got := count.Load(); got != 1 {
+		t.Errorf("expected callback called once due to debouncing, got %d", got)
+	}
+}
+
+func TestCountSeverity(t *testing.T) {
+	w := &Watcher{}
+
+	tests := []struct {
+		severity string
+		field    string
+	}{
+		{"critical", "CriticalCount"},
+		{"high", "HighCount"},
+		{"medium", "MediumCount"},
+		{"low", "LowCount"},
+		{"unknown", "none"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.severity, func(t *testing.T) {
+			s := &StateSummary{}
+			w.countSeverity(s, tt.severity)
+
+			switch tt.severity {
+			case "critical":
+				if s.CriticalCount != 1 {
+					t.Errorf("expected CriticalCount=1, got %d", s.CriticalCount)
+				}
+			case "high":
+				if s.HighCount != 1 {
+					t.Errorf("expected HighCount=1, got %d", s.HighCount)
+				}
+			case "medium":
+				if s.MediumCount != 1 {
+					t.Errorf("expected MediumCount=1, got %d", s.MediumCount)
+				}
+			case "low":
+				if s.LowCount != 1 {
+					t.Errorf("expected LowCount=1, got %d", s.LowCount)
+				}
+			case "unknown":
+				// No field should be incremented
+				if s.CriticalCount+s.HighCount+s.MediumCount+s.LowCount != 0 {
+					t.Error("unknown severity should not increment any count")
+				}
+			}
+		})
+	}
+}
+
+func TestCountSeverityMultiple(t *testing.T) {
+	w := &Watcher{}
+	s := &StateSummary{}
+
+	w.countSeverity(s, "critical")
+	w.countSeverity(s, "critical")
+	w.countSeverity(s, "high")
+	w.countSeverity(s, "medium")
+	w.countSeverity(s, "medium")
+	w.countSeverity(s, "medium")
+	w.countSeverity(s, "low")
+
+	if s.CriticalCount != 2 {
+		t.Errorf("expected CriticalCount=2, got %d", s.CriticalCount)
+	}
+	if s.HighCount != 1 {
+		t.Errorf("expected HighCount=1, got %d", s.HighCount)
+	}
+	if s.MediumCount != 3 {
+		t.Errorf("expected MediumCount=3, got %d", s.MediumCount)
+	}
+	if s.LowCount != 1 {
+		t.Errorf("expected LowCount=1, got %d", s.LowCount)
+	}
+}
+
+func TestDiffFindingsNewRBAC(t *testing.T) {
+	w := &Watcher{}
+
+	oldState := &WatchState{
+		RBACFindings: []analysis.RBACFinding{
+			{
+				CheckID:  "RBAC001",
+				Title:    "Existing finding",
+				Severity: graph.SeverityHigh,
+				Affected: []analysis.AffectedResource{
+					{Namespace: "default", Name: "sa1"},
+				},
+			},
+		},
+	}
+
+	newState := &WatchState{
+		RBACFindings: []analysis.RBACFinding{
+			{
+				CheckID:  "RBAC001",
+				Title:    "Existing finding",
+				Severity: graph.SeverityHigh,
+				Affected: []analysis.AffectedResource{
+					{Namespace: "default", Name: "sa1"},
+				},
+			},
+			{
+				CheckID:  "RBAC002",
+				Title:    "New finding",
+				Severity: graph.SeverityCritical,
+				Affected: []analysis.AffectedResource{
+					{Namespace: "kube-system", Name: "admin"},
+				},
+			},
+		},
+	}
+
+	changes := w.diffFindings(oldState, newState)
+
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 new finding, got %d", len(changes))
+	}
+	if changes[0].CheckID != "RBAC002" {
+		t.Errorf("expected CheckID RBAC002, got %s", changes[0].CheckID)
+	}
+	if changes[0].Type != "rbac" {
+		t.Errorf("expected type 'rbac', got %s", changes[0].Type)
+	}
+	if changes[0].Severity != "critical" {
+		t.Errorf("expected severity 'critical', got %s", changes[0].Severity)
+	}
+	if changes[0].Affected != "kube-system/admin" {
+		t.Errorf("expected affected 'kube-system/admin', got %s", changes[0].Affected)
+	}
+}
+
+func TestDiffFindingsNewPodSec(t *testing.T) {
+	w := &Watcher{}
+
+	oldState := &WatchState{
+		PodSecFindings: []analysis.PodSecurityFinding{},
+	}
+
+	newState := &WatchState{
+		PodSecFindings: []analysis.PodSecurityFinding{
+			{
+				CheckID:  "PSS001",
+				Title:    "Privileged container",
+				Severity: graph.SeverityCritical,
+				Affected: []analysis.AffectedWorkload{
+					{Namespace: "prod", Name: "web-app"},
+				},
+			},
+		},
+	}
+
+	changes := w.diffFindings(oldState, newState)
+
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 new finding, got %d", len(changes))
+	}
+	if changes[0].CheckID != "PSS001" {
+		t.Errorf("expected CheckID PSS001, got %s", changes[0].CheckID)
+	}
+	if changes[0].Type != "pod_security" {
+		t.Errorf("expected type 'pod_security', got %s", changes[0].Type)
+	}
+	if changes[0].Affected != "prod/web-app" {
+		t.Errorf("expected affected 'prod/web-app', got %s", changes[0].Affected)
+	}
+}
+
+func TestDiffFindingsNoChanges(t *testing.T) {
+	w := &Watcher{}
+
+	state := &WatchState{
+		RBACFindings: []analysis.RBACFinding{
+			{
+				CheckID:  "RBAC001",
+				Severity: graph.SeverityHigh,
+				Affected: []analysis.AffectedResource{
+					{Namespace: "default", Name: "sa1"},
+				},
+			},
+		},
+		PodSecFindings: []analysis.PodSecurityFinding{
+			{
+				CheckID:  "PSS001",
+				Severity: graph.SeverityMedium,
+				Affected: []analysis.AffectedWorkload{
+					{Namespace: "default", Name: "web"},
+				},
+			},
+		},
+	}
+
+	changes := w.diffFindings(state, state)
+
+	if len(changes) != 0 {
+		t.Errorf("expected 0 changes when states are the same, got %d", len(changes))
+	}
+}
+
+func TestDiffFindingsEmptyAffected(t *testing.T) {
+	w := &Watcher{}
+
+	oldState := &WatchState{
+		RBACFindings: []analysis.RBACFinding{
+			{CheckID: "RBAC001", Severity: graph.SeverityHigh, Affected: nil},
+		},
+	}
+
+	newState := &WatchState{
+		RBACFindings: []analysis.RBACFinding{
+			{CheckID: "RBAC001", Severity: graph.SeverityHigh, Affected: nil},
+			{CheckID: "RBAC002", Severity: graph.SeverityCritical, Affected: nil},
+		},
+	}
+
+	changes := w.diffFindings(oldState, newState)
+
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(changes))
+	}
+	if changes[0].CheckID != "RBAC002" {
+		t.Errorf("expected RBAC002, got %s", changes[0].CheckID)
+	}
+	if changes[0].Affected != "" {
+		t.Errorf("expected empty affected, got %q", changes[0].Affected)
+	}
+}
+
+func TestFindingKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		affected []analysis.AffectedResource
+		want     string
+	}{
+		{"nil", nil, ""},
+		{"empty", []analysis.AffectedResource{}, ""},
+		{"single", []analysis.AffectedResource{{Namespace: "ns", Name: "sa"}}, "ns/sa"},
+		{"cluster-scoped", []analysis.AffectedResource{{Name: "admin"}}, "/admin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findingKey(tt.affected)
+			if got != tt.want {
+				t.Errorf("findingKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPodSecFindingKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		affected []analysis.AffectedWorkload
+		want     string
+	}{
+		{"nil", nil, ""},
+		{"empty", []analysis.AffectedWorkload{}, ""},
+		{"single", []analysis.AffectedWorkload{{Namespace: "prod", Name: "web"}}, "prod/web"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := podSecFindingKey(tt.affected)
+			if got != tt.want {
+				t.Errorf("podSecFindingKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatAffected(t *testing.T) {
+	tests := []struct {
+		name     string
+		affected []analysis.AffectedResource
+		want     string
+	}{
+		{"nil", nil, ""},
+		{"empty", []analysis.AffectedResource{}, ""},
+		{"with-namespace", []analysis.AffectedResource{{Namespace: "ns", Name: "sa"}}, "ns/sa"},
+		{"without-namespace", []analysis.AffectedResource{{Name: "cluster-role"}}, "cluster-role"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatAffected(tt.affected)
+			if got != tt.want {
+				t.Errorf("formatAffected() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatPodSecAffected(t *testing.T) {
+	tests := []struct {
+		name     string
+		affected []analysis.AffectedWorkload
+		want     string
+	}{
+		{"nil", nil, ""},
+		{"empty", []analysis.AffectedWorkload{}, ""},
+		{"with-namespace", []analysis.AffectedWorkload{{Namespace: "prod", Name: "deploy"}}, "prod/deploy"},
+		{"without-namespace", []analysis.AffectedWorkload{{Name: "deploy"}}, "deploy"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatPodSecAffected(tt.affected)
+			if got != tt.want {
+				t.Errorf("formatPodSecAffected() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigStruct(t *testing.T) {
+	cfg := Config{}
+
+	// Verify zero values
+	if cfg.Kubeconfig != "" {
+		t.Error("expected empty Kubeconfig")
+	}
+	if cfg.AllNamespaces {
+		t.Error("expected AllNamespaces false by default")
+	}
+	if cfg.IncludeSystem {
+		t.Error("expected IncludeSystem false by default")
+	}
+	if cfg.ResyncPeriod != 0 {
+		t.Error("expected zero ResyncPeriod")
+	}
+	if cfg.DebouncePeriod != 0 {
+		t.Error("expected zero DebouncePeriod")
+	}
+	if cfg.MaxMemoryMB != 0 {
+		t.Error("expected zero MaxMemoryMB")
+	}
+}
+
+func TestWatchStateStruct(t *testing.T) {
+	now := time.Now()
+	state := &WatchState{
+		Timestamp: now,
+		Summary: StateSummary{
+			TotalFindings: 10,
+			CriticalCount: 1,
+			HighCount:     2,
+			MediumCount:   3,
+			LowCount:      4,
+			WorkloadCount: 5,
+			SACount:       6,
+			RoleCount:     7,
+		},
+	}
+
+	if state.Timestamp != now {
+		t.Error("timestamp mismatch")
+	}
+	if state.Summary.TotalFindings != 10 {
+		t.Error("TotalFindings mismatch")
+	}
+}
+
+func TestFindingChangeStruct(t *testing.T) {
+	fc := FindingChange{
+		Type:     "rbac",
+		CheckID:  "RBAC001",
+		Name:     "Test",
+		Severity: "critical",
+		Affected: "default/sa",
+	}
+
+	if fc.Type != "rbac" {
+		t.Error("Type mismatch")
+	}
+	if fc.CheckID != "RBAC001" {
+		t.Error("CheckID mismatch")
+	}
+}

--- a/pkg/watch/webhook_test.go
+++ b/pkg/watch/webhook_test.go
@@ -1,0 +1,309 @@
+package watch
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+func TestNewWebhookNotifier(t *testing.T) {
+	headers := map[string]string{"Authorization": "Bearer token123"}
+	w := NewWebhookNotifier("http://example.com/hook", headers)
+
+	if w == nil {
+		t.Fatal("NewWebhookNotifier returned nil")
+	}
+	if w.url != "http://example.com/hook" {
+		t.Errorf("unexpected url: %s", w.url)
+	}
+	if w.headers["Authorization"] != "Bearer token123" {
+		t.Error("headers not set correctly")
+	}
+	if w.client == nil {
+		t.Error("client should not be nil")
+	}
+}
+
+func TestWebhookSendEmptyFindings(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	notifier := NewWebhookNotifier(srv.URL, nil)
+	notifier.Send([]FindingChange{})
+
+	if called {
+		t.Error("Send should not call webhook with empty findings")
+	}
+}
+
+func TestWebhookSendNilFindings(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	notifier := NewWebhookNotifier(srv.URL, nil)
+	notifier.Send(nil)
+
+	if called {
+		t.Error("Send should not call webhook with nil findings")
+	}
+}
+
+func TestWebhookSendPayload(t *testing.T) {
+	var mu sync.Mutex
+	var receivedBody []byte
+	var receivedHeaders http.Header
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		var err error
+		receivedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read body: %v", err)
+		}
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	headers := map[string]string{"X-Custom": "test-value"}
+	notifier := NewWebhookNotifier(srv.URL, headers)
+
+	findings := []FindingChange{
+		{Type: "rbac", CheckID: "RBAC001", Name: "Wildcard access", Severity: "critical", Affected: "default/admin"},
+		{Type: "rbac", CheckID: "RBAC002", Name: "High privilege", Severity: "high", Affected: "default/app"},
+		{Type: "pod_security", CheckID: "PSS001", Name: "Privileged container", Severity: "medium", Affected: "default/web"},
+	}
+
+	notifier.Send(findings)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Verify Content-Type
+	if receivedHeaders.Get("Content-Type") != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %s", receivedHeaders.Get("Content-Type"))
+	}
+
+	// Verify custom header
+	if receivedHeaders.Get("X-Custom") != "test-value" {
+		t.Errorf("expected X-Custom header, got %s", receivedHeaders.Get("X-Custom"))
+	}
+
+	// Parse payload
+	var payload WebhookPayload
+	if err := json.Unmarshal(receivedBody, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	if payload.Event != "new_findings" {
+		t.Errorf("expected event 'new_findings', got %q", payload.Event)
+	}
+	if payload.Timestamp.IsZero() {
+		t.Error("timestamp should not be zero")
+	}
+	if len(payload.Findings) != 3 {
+		t.Errorf("expected 3 findings, got %d", len(payload.Findings))
+	}
+	if payload.Summary.NewFindings != 3 {
+		t.Errorf("expected NewFindings=3, got %d", payload.Summary.NewFindings)
+	}
+	if payload.Summary.CriticalCount != 1 {
+		t.Errorf("expected CriticalCount=1, got %d", payload.Summary.CriticalCount)
+	}
+	if payload.Summary.HighCount != 1 {
+		t.Errorf("expected HighCount=1, got %d", payload.Summary.HighCount)
+	}
+
+	// Verify individual finding fields
+	f := payload.Findings[0]
+	if f.Type != "rbac" || f.CheckID != "RBAC001" || f.Severity != "critical" {
+		t.Errorf("unexpected first finding: %+v", f)
+	}
+}
+
+func TestSlackSendEmptyFindings(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	notifier := NewWebhookNotifier(srv.URL, nil)
+	notifier.SendSlack([]FindingChange{})
+
+	if called {
+		t.Error("SendSlack should not call webhook with empty findings")
+	}
+}
+
+func TestSlackSendPayload(t *testing.T) {
+	var mu sync.Mutex
+	var receivedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		var err error
+		receivedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	notifier := NewWebhookNotifier(srv.URL, nil)
+
+	findings := []FindingChange{
+		{Type: "rbac", CheckID: "RBAC001", Name: "Wildcard access", Severity: "critical", Affected: "default/admin"},
+		{Type: "rbac", CheckID: "RBAC002", Name: "High privilege", Severity: "high", Affected: "default/app"},
+	}
+
+	notifier.SendSlack(findings)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	var payload SlackPayload
+	if err := json.Unmarshal(receivedBody, &payload); err != nil {
+		t.Fatalf("failed to unmarshal slack payload: %v", err)
+	}
+
+	if payload.Text == "" {
+		t.Error("slack text should not be empty")
+	}
+	if !contains(payload.Text, "2 new security findings") {
+		t.Errorf("unexpected text: %s", payload.Text)
+	}
+
+	if len(payload.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(payload.Attachments))
+	}
+
+	att := payload.Attachments[0]
+	if att.Color != "danger" {
+		t.Errorf("expected color 'danger' for critical finding, got %q", att.Color)
+	}
+	if att.Footer != "Identity Chain Watcher" {
+		t.Errorf("unexpected footer: %s", att.Footer)
+	}
+	if !contains(att.Title, "1 Critical") || !contains(att.Title, "1 High") {
+		t.Errorf("unexpected title: %s", att.Title)
+	}
+}
+
+func TestSlackSendWarningColor(t *testing.T) {
+	var mu sync.Mutex
+	var receivedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		var err error
+		receivedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	notifier := NewWebhookNotifier(srv.URL, nil)
+
+	// Only high severity, no critical -- should use "warning" color
+	findings := []FindingChange{
+		{Type: "rbac", CheckID: "RBAC002", Name: "High privilege", Severity: "high", Affected: "default/app"},
+	}
+
+	notifier.SendSlack(findings)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	var payload SlackPayload
+	if err := json.Unmarshal(receivedBody, &payload); err != nil {
+		t.Fatalf("failed to unmarshal slack payload: %v", err)
+	}
+
+	if len(payload.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(payload.Attachments))
+	}
+	if payload.Attachments[0].Color != "warning" {
+		t.Errorf("expected 'warning' color with no critical findings, got %q", payload.Attachments[0].Color)
+	}
+}
+
+func TestSlackSendManyFindings(t *testing.T) {
+	var mu sync.Mutex
+	var receivedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		var err error
+		receivedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	notifier := NewWebhookNotifier(srv.URL, nil)
+
+	// More than 5 findings to test truncation
+	findings := make([]FindingChange, 8)
+	for i := range findings {
+		findings[i] = FindingChange{
+			Type:     "rbac",
+			CheckID:  "RBAC001",
+			Name:     "Test finding",
+			Severity: "high",
+			Affected: "default/test",
+		}
+	}
+
+	notifier.SendSlack(findings)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	var payload SlackPayload
+	if err := json.Unmarshal(receivedBody, &payload); err != nil {
+		t.Fatalf("failed to unmarshal slack payload: %v", err)
+	}
+
+	// The attachment text should contain "... and 3 more"
+	if len(payload.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(payload.Attachments))
+	}
+	if !contains(payload.Attachments[0].Text, "and 3 more") {
+		t.Errorf("expected truncation message, got: %s", payload.Attachments[0].Text)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Adds comprehensive unit test coverage for `pkg/graph`, `pkg/collector`, `pkg/collector/cloud`, `pkg/remediation`, `pkg/watch`, `pkg/output`, and `pkg/checks`
- 21 test files with ~400+ test cases covering happy paths and error paths
- All tests pass with `go test ./...`

## Packages covered
| Package | Tests | Coverage highlights |
|---------|-------|-------------------|
| `pkg/graph` | node, edge, graph, builder | All CRUD ops, K8s resource building, cloud edges, network exposure |
| `pkg/collector` | collector, kubernetes, openshift | Namespace filtering, fake k8s client collection, SCC parsing |
| `pkg/collector/cloud` | cloud, aws, gcp, azure | Provider detection, severity classification, IAM helpers |
| `pkg/remediation` | remediation, generator, rbac, podsecurity, networkpolicy | All check IDs, filtering, manifest generation |
| `pkg/watch` | watcher, metrics, webhook | Debouncer, Prometheus metrics, webhook/Slack payloads |
| `pkg/output` | output, json, table, sarif | All writer methods, valid JSON/SARIF output |
| `pkg/checks` | custom | YAML loading, condition evaluation, graph matching |

## Test plan
- [x] `go test ./...` passes
- [x] No new dependencies added
- [x] Table-driven tests following Go conventions
- [x] Fake/mock clients used for Kubernetes (client-go/fake)
- [x] Pure logic tested for cloud SDKs (no real credentials needed)

Addresses #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)