### PR TITLE
feat: baseline drift detection — snapshot, diff, and watch integration

### DIFF
--- a/cmd/idc/main.go
+++ b/cmd/idc/main.go
@@ -2691,6 +2691,9 @@ func watchCmd() *cobra.Command {
 	var resyncPeriod string
 	var debouncePeriod string
 	var maxMemoryMB int
+	var baselineFile string
+	var alertOnDrift bool
+	var driftOnly bool
 
 	cmd := &cobra.Command{
 		Use:   "watch",
@@ -2705,6 +2708,8 @@ Examples:
   idc watch -A
   idc watch -A --metrics-addr :8080
   idc watch -A --webhook-url https://hooks.slack.com/...
+  idc watch -A --baseline baseline.json --alert-on-drift
+  idc watch -A --baseline baseline.json --drift-only
   idc watch -A --resync-period 5m --debounce 30s --max-memory 256`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resync, err := time.ParseDuration(resyncPeriod)
@@ -2728,6 +2733,9 @@ Examples:
 				MaxMemoryMB:    maxMemoryMB,
 				MetricsAddr:    metricsAddr,
 				WebhookURL:     webhookURL,
+				BaselineFile:   baselineFile,
+				AlertOnDrift:   alertOnDrift,
+				DriftOnly:      driftOnly,
 			}
 
 			watcher, err := watch.New(config)
@@ -2745,6 +2753,9 @@ Examples:
 	cmd.Flags().StringVar(&resyncPeriod, "resync-period", "5m", "How often to fully resync with the API server")
 	cmd.Flags().StringVar(&debouncePeriod, "debounce", "30s", "Wait time after changes before re-analyzing")
 	cmd.Flags().IntVar(&maxMemoryMB, "max-memory", 0, "Maximum memory limit in MB (0 = no limit)")
+	cmd.Flags().StringVar(&baselineFile, "baseline", "", "Baseline snapshot file for drift detection")
+	cmd.Flags().BoolVar(&alertOnDrift, "alert-on-drift", false, "Alert when identity posture drifts from baseline")
+	cmd.Flags().BoolVar(&driftOnly, "drift-only", false, "Only output drift changes from baseline (suppress normal output)")
 
 	return cmd
 }
@@ -2826,6 +2837,67 @@ Examples:
 	return cmd
 }
 
+func runSnapshotScan(outputFile string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	g, err := collectGraph(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to collect cluster data: %w", err)
+	}
+
+	opts := analysis.RBACAuditOptions{
+		IncludeSystem: includeSystem,
+		Namespace:     namespace,
+	}
+	if allNamespaces {
+		opts.Namespace = ""
+	}
+	rbacResult := analysis.RunRBACAudit(g, opts)
+
+	podSecOpts := analysis.PodSecurityOptions{
+		IncludeSystem: includeSystem,
+		Namespace:     namespace,
+	}
+	if allNamespaces {
+		podSecOpts.Namespace = ""
+	}
+	podSecResult := analysis.RunPodSecurityAudit(g, podSecOpts)
+
+	netPolOpts := analysis.NetworkPolicyOptions{
+		IncludeSystem: includeSystem,
+		Namespace:     namespace,
+	}
+	if allNamespaces {
+		netPolOpts.Namespace = ""
+	}
+	netPolResult := analysis.RunNetworkPolicyAudit(g, netPolOpts)
+
+	var cloudFindings []analysis.CloudIAMFinding
+	if includeCloud {
+		cloudResult := analysis.AnalyzeCloudIAM(g)
+		cloudFindings = cloudResult.Findings
+	}
+
+	stats := g.Stats()
+	graphStats := &analysis.SnapshotGraphStats{
+		TotalNodes:    stats.TotalNodes,
+		TotalEdges:    stats.TotalEdges,
+		WorkloadCount: stats.NodeCounts[graph.NodeWorkload],
+		SACount:       stats.NodeCounts[graph.NodeServiceAccount],
+		RoleCount:     stats.NodeCounts[graph.NodeRole],
+	}
+
+	snap := analysis.NewSnapshot(analysis.ScanFindings{
+		RBACFindings:   rbacResult.Findings,
+		PodSecFindings: podSecResult.Findings,
+		NetPolFindings: netPolResult.Findings,
+		CloudFindings:  cloudFindings,
+	}, graphStats)
+
+	return analysis.WriteSnapshot(snap, outputFile)
+}
+
 func snapshotCmd() *cobra.Command {
 	var outputFile string
 
@@ -2837,116 +2909,125 @@ Use with 'idc diff' to compare snapshots over time.
 
 Examples:
   idc snapshot -A -f baseline.json
+  idc snapshot save -A --output baseline.json
   idc snapshot -A --include-cloud --aws-region us-west-2 -f baseline.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-			defer cancel()
-
-			g, err := collectGraph(ctx)
-			if err != nil {
-				return fmt.Errorf("failed to collect cluster data: %w", err)
-			}
-
-			opts := analysis.RBACAuditOptions{
-				IncludeSystem: includeSystem,
-				Namespace:     namespace,
-			}
-			if allNamespaces {
-				opts.Namespace = ""
-			}
-			rbacResult := analysis.RunRBACAudit(g, opts)
-
-			podSecOpts := analysis.PodSecurityOptions{
-				IncludeSystem: includeSystem,
-				Namespace:     namespace,
-			}
-			if allNamespaces {
-				podSecOpts.Namespace = ""
-			}
-			podSecResult := analysis.RunPodSecurityAudit(g, podSecOpts)
-
-			netPolOpts := analysis.NetworkPolicyOptions{
-				IncludeSystem: includeSystem,
-				Namespace:     namespace,
-			}
-			if allNamespaces {
-				netPolOpts.Namespace = ""
-			}
-			netPolResult := analysis.RunNetworkPolicyAudit(g, netPolOpts)
-
-			var cloudFindings []analysis.CloudIAMFinding
-			if includeCloud {
-				cloudResult := analysis.AnalyzeCloudIAM(g)
-				cloudFindings = cloudResult.Findings
-			}
-
-			snapshot := struct {
-				Timestamp       string                          `json:"timestamp"`
-				RBACFindings    []analysis.RBACFinding          `json:"rbac_findings"`
-				PodSecFindings  []analysis.PodSecurityFinding   `json:"pod_security_findings"`
-				NetPolFindings  []analysis.NetworkPolicyFinding `json:"network_policy_findings"`
-				CloudFindings   []analysis.CloudIAMFinding      `json:"cloud_findings"`
-			}{
-				Timestamp:      time.Now().UTC().Format(time.RFC3339),
-				RBACFindings:   rbacResult.Findings,
-				PodSecFindings: podSecResult.Findings,
-				NetPolFindings: netPolResult.Findings,
-				CloudFindings:  cloudFindings,
-			}
-
-			var w *os.File
-			if outputFile != "" {
-				var err error
-				w, err = os.Create(outputFile)
-				if err != nil {
-					return fmt.Errorf("failed to create output file: %w", err)
-				}
-				defer w.Close()
-			} else {
-				w = os.Stdout
-			}
-
-			encoder := json.NewEncoder(w)
-			encoder.SetIndent("", "  ")
-			return encoder.Encode(snapshot)
+			return runSnapshotScan(outputFile)
 		},
 	}
 
 	cmd.Flags().StringVarP(&outputFile, "output-file", "f", "", "Output file path (default: stdout)")
 
+	// 'save' subcommand
+	var saveOutput string
+	saveCmd := &cobra.Command{
+		Use:   "save",
+		Short: "Save a snapshot of current security findings",
+		Long: `Save a JSON snapshot of all current security findings as a known-good baseline.
+
+Examples:
+  idc snapshot save -A --output baseline.json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSnapshotScan(saveOutput)
+		},
+	}
+	saveCmd.Flags().StringVar(&saveOutput, "output", "", "Output file path (default: stdout)")
+	cmd.AddCommand(saveCmd)
+
 	return cmd
+}
+
+func printDiffResult(result *analysis.DiffResult) {
+	fmt.Printf("Security Posture Comparison\n")
+	fmt.Printf("===========================\n\n")
+	fmt.Printf("Status: %s\n\n", strings.ToUpper(result.Summary.Status))
+	fmt.Printf("Baseline: %d findings\n", result.Summary.BaselineTotal)
+	fmt.Printf("Current:  %d findings\n\n", result.Summary.CurrentTotal)
+
+	if len(result.NewFindings) > 0 {
+		fmt.Printf("NEW FINDINGS (%d):\n", len(result.NewFindings))
+		fmt.Printf("-----------------\n")
+		for _, f := range result.NewFindings {
+			fmt.Printf("  [%s] %s - %s\n", f.Severity, f.CheckID, f.Title)
+			if f.Namespace != "" {
+				fmt.Printf("         Namespace: %s, Resource: %s\n", f.Namespace, f.Resource)
+			} else if f.Resource != "" {
+				fmt.Printf("         Resource: %s\n", f.Resource)
+			}
+		}
+		fmt.Println()
+	}
+
+	if len(result.ResolvedFindings) > 0 {
+		fmt.Printf("RESOLVED FINDINGS (%d):\n", len(result.ResolvedFindings))
+		fmt.Printf("----------------------\n")
+		for _, f := range result.ResolvedFindings {
+			fmt.Printf("  [%s] %s - %s\n", f.Severity, f.CheckID, f.Title)
+			if f.Namespace != "" {
+				fmt.Printf("         Namespace: %s, Resource: %s\n", f.Namespace, f.Resource)
+			} else if f.Resource != "" {
+				fmt.Printf("         Resource: %s\n", f.Resource)
+			}
+		}
+		fmt.Println()
+	}
+
+	fmt.Printf("Unchanged: %d findings\n", result.UnchangedCount)
 }
 
 func diffCmd() *cobra.Command {
 	var baselineFile string
+	var fromFile string
+	var toFile string
 
 	cmd := &cobra.Command{
 		Use:   "diff",
 		Short: "Compare current findings against a baseline snapshot",
-		Long: `Compare the current security state against a previously saved baseline.
+		Long: `Compare the current security state against a previously saved baseline,
+or compare two snapshot files offline.
 Shows new findings, resolved findings, and overall trend.
 
 Examples:
   idc diff -A --baseline baseline.json
-  idc diff -A --baseline before.json -o json`,
+  idc diff -A --baseline before.json -o json
+  idc diff --from baseline.json --to current.json
+  idc diff --from baseline.json --to current.json -o json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Offline mode: compare two files
+			if fromFile != "" && toFile != "" {
+				fromFindings, err := analysis.LoadScanFindings(fromFile)
+				if err != nil {
+					return fmt.Errorf("failed to load --from file: %w", err)
+				}
+
+				toFindings, err := analysis.LoadScanFindings(toFile)
+				if err != nil {
+					return fmt.Errorf("failed to load --to file: %w", err)
+				}
+
+				result := analysis.ComputeDiff(fromFindings, toFindings)
+
+				if outputFormat == "json" {
+					encoder := json.NewEncoder(os.Stdout)
+					encoder.SetIndent("", "  ")
+					return encoder.Encode(result)
+				}
+
+				printDiffResult(result)
+				return nil
+			}
+
+			if fromFile != "" || toFile != "" {
+				return fmt.Errorf("both --from and --to are required for offline comparison")
+			}
+
 			if baselineFile == "" {
-				return fmt.Errorf("--baseline is required")
+				return fmt.Errorf("--baseline is required (or use --from and --to for offline comparison)")
 			}
 
-			baselineData, err := os.ReadFile(baselineFile)
+			baselineFindings, err := analysis.LoadScanFindings(baselineFile)
 			if err != nil {
-				return fmt.Errorf("failed to read baseline file: %w", err)
-			}
-
-			var baseline struct {
-				RBACFindings   []analysis.RBACFinding          `json:"rbac_findings"`
-				PodSecFindings []analysis.PodSecurityFinding   `json:"pod_security_findings"`
-				NetPolFindings []analysis.NetworkPolicyFinding `json:"network_policy_findings"`
-				CloudFindings  []analysis.CloudIAMFinding      `json:"cloud_findings"`
-			}
-			if err := json.Unmarshal(baselineData, &baseline); err != nil {
-				return fmt.Errorf("failed to parse baseline: %w", err)
+				return fmt.Errorf("failed to load baseline: %w", err)
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
@@ -2988,13 +3069,6 @@ Examples:
 			if includeCloud {
 				cloudResult := analysis.AnalyzeCloudIAM(g)
 				cloudFindings = cloudResult.Findings
-			}
-
-			baselineFindings := &analysis.ScanFindings{
-				RBACFindings:   baseline.RBACFindings,
-				PodSecFindings: baseline.PodSecFindings,
-				NetPolFindings: baseline.NetPolFindings,
-				CloudFindings:  baseline.CloudFindings,
 			}
 
 			currentFindings := &analysis.ScanFindings{
@@ -3012,47 +3086,14 @@ Examples:
 				return encoder.Encode(result)
 			}
 
-			fmt.Printf("Security Posture Comparison\n")
-			fmt.Printf("===========================\n\n")
-			fmt.Printf("Status: %s\n\n", strings.ToUpper(result.Summary.Status))
-			fmt.Printf("Baseline: %d findings\n", result.Summary.BaselineTotal)
-			fmt.Printf("Current:  %d findings\n\n", result.Summary.CurrentTotal)
-
-			if len(result.NewFindings) > 0 {
-				fmt.Printf("NEW FINDINGS (%d):\n", len(result.NewFindings))
-				fmt.Printf("-----------------\n")
-				for _, f := range result.NewFindings {
-					fmt.Printf("  [%s] %s - %s\n", f.Severity, f.CheckID, f.Title)
-					if f.Namespace != "" {
-						fmt.Printf("         Namespace: %s, Resource: %s\n", f.Namespace, f.Resource)
-					} else if f.Resource != "" {
-						fmt.Printf("         Resource: %s\n", f.Resource)
-					}
-				}
-				fmt.Println()
-			}
-
-			if len(result.ResolvedFindings) > 0 {
-				fmt.Printf("RESOLVED FINDINGS (%d):\n", len(result.ResolvedFindings))
-				fmt.Printf("----------------------\n")
-				for _, f := range result.ResolvedFindings {
-					fmt.Printf("  [%s] %s - %s\n", f.Severity, f.CheckID, f.Title)
-					if f.Namespace != "" {
-						fmt.Printf("         Namespace: %s, Resource: %s\n", f.Namespace, f.Resource)
-					} else if f.Resource != "" {
-						fmt.Printf("         Resource: %s\n", f.Resource)
-					}
-				}
-				fmt.Println()
-			}
-
-			fmt.Printf("Unchanged: %d findings\n", result.UnchangedCount)
-
+			printDiffResult(result)
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&baselineFile, "baseline", "", "Baseline snapshot file to compare against (required)")
+	cmd.Flags().StringVar(&baselineFile, "baseline", "", "Baseline snapshot file to compare against live cluster")
+	cmd.Flags().StringVar(&fromFile, "from", "", "Source snapshot file for offline comparison")
+	cmd.Flags().StringVar(&toFile, "to", "", "Target snapshot file for offline comparison")
 
 	return cmd
 }

--- a/pkg/analysis/diff_test.go
+++ b/pkg/analysis/diff_test.go
@@ -1,0 +1,212 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+func TestComputeDiff_NilBaseline(t *testing.T) {
+	current := &ScanFindings{
+		RBACFindings: []RBACFinding{
+			{CheckID: "RBAC001", Title: "Wildcard verbs", Severity: graph.SeverityHigh,
+				Affected: []AffectedResource{{Namespace: "default", Name: "admin"}}},
+		},
+	}
+
+	result := ComputeDiff(nil, current)
+
+	if result.Summary.NewCount != 1 {
+		t.Errorf("expected 1 new finding, got %d", result.Summary.NewCount)
+	}
+	if result.Summary.ResolvedCount != 0 {
+		t.Errorf("expected 0 resolved, got %d", result.Summary.ResolvedCount)
+	}
+	if result.Summary.Status != "degraded" {
+		t.Errorf("expected status degraded, got %s", result.Summary.Status)
+	}
+}
+
+func TestComputeDiff_Unchanged(t *testing.T) {
+	findings := &ScanFindings{
+		RBACFindings: []RBACFinding{
+			{CheckID: "RBAC001", Title: "Wildcard verbs", Severity: graph.SeverityHigh,
+				Affected: []AffectedResource{{Namespace: "default", Name: "admin"}}},
+		},
+	}
+
+	result := ComputeDiff(findings, findings)
+
+	if result.Summary.Status != "unchanged" {
+		t.Errorf("expected status unchanged, got %s", result.Summary.Status)
+	}
+	if result.Summary.NewCount != 0 {
+		t.Errorf("expected 0 new, got %d", result.Summary.NewCount)
+	}
+	if result.Summary.ResolvedCount != 0 {
+		t.Errorf("expected 0 resolved, got %d", result.Summary.ResolvedCount)
+	}
+	if result.UnchangedCount != 1 {
+		t.Errorf("expected 1 unchanged, got %d", result.UnchangedCount)
+	}
+}
+
+func TestComputeDiff_NewFindings(t *testing.T) {
+	baseline := &ScanFindings{
+		RBACFindings: []RBACFinding{
+			{CheckID: "RBAC001", Title: "Wildcard verbs", Severity: graph.SeverityHigh,
+				Affected: []AffectedResource{{Namespace: "default", Name: "admin"}}},
+		},
+	}
+
+	current := &ScanFindings{
+		RBACFindings: []RBACFinding{
+			{CheckID: "RBAC001", Title: "Wildcard verbs", Severity: graph.SeverityHigh,
+				Affected: []AffectedResource{{Namespace: "default", Name: "admin"}}},
+			{CheckID: "RBAC002", Title: "Cluster admin binding", Severity: graph.SeverityCritical,
+				Affected: []AffectedResource{{Namespace: "kube-system", Name: "superuser"}}},
+		},
+	}
+
+	result := ComputeDiff(baseline, current)
+
+	if result.Summary.NewCount != 1 {
+		t.Errorf("expected 1 new finding, got %d", result.Summary.NewCount)
+	}
+	if result.Summary.Status != "degraded" {
+		t.Errorf("expected status degraded, got %s", result.Summary.Status)
+	}
+	if len(result.NewFindings) != 1 {
+		t.Fatalf("expected 1 new finding, got %d", len(result.NewFindings))
+	}
+	if result.NewFindings[0].CheckID != "RBAC002" {
+		t.Errorf("expected new finding RBAC002, got %s", result.NewFindings[0].CheckID)
+	}
+}
+
+func TestComputeDiff_ResolvedFindings(t *testing.T) {
+	baseline := &ScanFindings{
+		RBACFindings: []RBACFinding{
+			{CheckID: "RBAC001", Title: "Wildcard verbs", Severity: graph.SeverityHigh,
+				Affected: []AffectedResource{{Namespace: "default", Name: "admin"}}},
+			{CheckID: "RBAC002", Title: "Cluster admin binding", Severity: graph.SeverityCritical,
+				Affected: []AffectedResource{{Namespace: "kube-system", Name: "superuser"}}},
+		},
+	}
+
+	current := &ScanFindings{
+		RBACFindings: []RBACFinding{
+			{CheckID: "RBAC001", Title: "Wildcard verbs", Severity: graph.SeverityHigh,
+				Affected: []AffectedResource{{Namespace: "default", Name: "admin"}}},
+		},
+	}
+
+	result := ComputeDiff(baseline, current)
+
+	if result.Summary.ResolvedCount != 1 {
+		t.Errorf("expected 1 resolved finding, got %d", result.Summary.ResolvedCount)
+	}
+	if result.Summary.Status != "improved" {
+		t.Errorf("expected status improved, got %s", result.Summary.Status)
+	}
+	if len(result.ResolvedFindings) != 1 {
+		t.Fatalf("expected 1 resolved finding, got %d", len(result.ResolvedFindings))
+	}
+	if result.ResolvedFindings[0].CheckID != "RBAC002" {
+		t.Errorf("expected resolved finding RBAC002, got %s", result.ResolvedFindings[0].CheckID)
+	}
+}
+
+func TestComputeDiff_MixedChanges(t *testing.T) {
+	baseline := &ScanFindings{
+		RBACFindings: []RBACFinding{
+			{CheckID: "RBAC001", Title: "Wildcard verbs", Severity: graph.SeverityHigh,
+				Affected: []AffectedResource{{Namespace: "default", Name: "admin"}}},
+		},
+		PodSecFindings: []PodSecurityFinding{
+			{CheckID: "PSS001", Title: "Privileged container", Severity: graph.SeverityCritical,
+				Affected: []AffectedWorkload{{Namespace: "default", Name: "app"}}},
+		},
+	}
+
+	current := &ScanFindings{
+		RBACFindings: []RBACFinding{
+			{CheckID: "RBAC003", Title: "Secrets access", Severity: graph.SeverityMedium,
+				Affected: []AffectedResource{{Namespace: "prod", Name: "reader"}}},
+		},
+		PodSecFindings: []PodSecurityFinding{
+			{CheckID: "PSS001", Title: "Privileged container", Severity: graph.SeverityCritical,
+				Affected: []AffectedWorkload{{Namespace: "default", Name: "app"}}},
+		},
+	}
+
+	result := ComputeDiff(baseline, current)
+
+	if result.Summary.NewCount != 1 {
+		t.Errorf("expected 1 new, got %d", result.Summary.NewCount)
+	}
+	if result.Summary.ResolvedCount != 1 {
+		t.Errorf("expected 1 resolved, got %d", result.Summary.ResolvedCount)
+	}
+	if result.UnchangedCount != 1 {
+		t.Errorf("expected 1 unchanged, got %d", result.UnchangedCount)
+	}
+}
+
+func TestComputeDiff_CrossTypeFindings(t *testing.T) {
+	baseline := &ScanFindings{}
+
+	current := &ScanFindings{
+		RBACFindings: []RBACFinding{
+			{CheckID: "RBAC001", Title: "Test", Severity: graph.SeverityHigh,
+				Affected: []AffectedResource{{Namespace: "ns1", Name: "r1"}}},
+		},
+		NetPolFindings: []NetworkPolicyFinding{
+			{CheckID: "NET001", Title: "No network policy", Severity: graph.SeverityMedium,
+				Affected: []AffectedNetworkResource{{Namespace: "ns2", Name: "svc1"}}},
+		},
+		CloudFindings: []CloudIAMFinding{
+			{Title: "Admin role", Provider: "aws", Category: CloudCategoryAdminAccess,
+				Severity: graph.SeverityCritical, RoleARN: "arn:aws:iam::role/admin"},
+		},
+	}
+
+	result := ComputeDiff(baseline, current)
+
+	if result.Summary.NewCount != 3 {
+		t.Errorf("expected 3 new findings across types, got %d", result.Summary.NewCount)
+	}
+	if result.Summary.Status != "degraded" {
+		t.Errorf("expected status degraded, got %s", result.Summary.Status)
+	}
+}
+
+func TestComputeDiff_BothNil(t *testing.T) {
+	result := ComputeDiff(nil, nil)
+
+	if result.Summary.Status != "unchanged" {
+		t.Errorf("expected unchanged for nil/nil, got %s", result.Summary.Status)
+	}
+	if result.Summary.NewCount != 0 || result.Summary.ResolvedCount != 0 {
+		t.Error("expected no changes for nil/nil")
+	}
+}
+
+func TestComputeDiff_SeverityInOutput(t *testing.T) {
+	baseline := &ScanFindings{}
+	current := &ScanFindings{
+		RBACFindings: []RBACFinding{
+			{CheckID: "RBAC001", Title: "Test", Severity: graph.SeverityCritical,
+				Affected: []AffectedResource{{Namespace: "ns1", Name: "r1"}}},
+		},
+	}
+
+	result := ComputeDiff(baseline, current)
+
+	if len(result.NewFindings) != 1 {
+		t.Fatalf("expected 1 new finding, got %d", len(result.NewFindings))
+	}
+	if result.NewFindings[0].Severity != "critical" {
+		t.Errorf("expected severity critical, got %s", result.NewFindings[0].Severity)
+	}
+}

--- a/pkg/analysis/snapshot.go
+++ b/pkg/analysis/snapshot.go
@@ -1,0 +1,86 @@
+package analysis
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+// SnapshotVersion is the current snapshot format version.
+const SnapshotVersion = "1.0"
+
+// GraphStats holds high-level graph statistics for portability.
+type SnapshotGraphStats struct {
+	TotalNodes    int `json:"total_nodes"`
+	TotalEdges    int `json:"total_edges"`
+	WorkloadCount int `json:"workload_count"`
+	SACount       int `json:"service_account_count"`
+	RoleCount     int `json:"role_count"`
+}
+
+// Snapshot is the portable JSON format for a findings snapshot.
+type Snapshot struct {
+	Version    string                 `json:"version"`
+	Timestamp  string                 `json:"timestamp"`
+	GraphStats *SnapshotGraphStats    `json:"graph_stats,omitempty"`
+	Findings   ScanFindings           `json:"findings"`
+}
+
+// NewSnapshot creates a Snapshot with the current version and timestamp.
+func NewSnapshot(findings ScanFindings, graphStats *SnapshotGraphStats) *Snapshot {
+	return &Snapshot{
+		Version:    SnapshotVersion,
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		GraphStats: graphStats,
+		Findings:   findings,
+	}
+}
+
+// WriteSnapshot writes a snapshot to the given file path, or stdout if path is empty.
+func WriteSnapshot(snap *Snapshot, path string) error {
+	var w *os.File
+	if path != "" {
+		var err error
+		w, err = os.Create(path)
+		if err != nil {
+			return fmt.Errorf("failed to create output file: %w", err)
+		}
+		defer w.Close()
+	} else {
+		w = os.Stdout
+	}
+
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(snap)
+}
+
+// LoadScanFindings reads a snapshot file and returns the ScanFindings.
+// It supports both the new versioned format and the legacy flat format.
+func LoadScanFindings(path string) (*ScanFindings, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	return ParseScanFindings(data)
+}
+
+// ParseScanFindings parses snapshot JSON data and returns the ScanFindings.
+// It supports both the new versioned format and the legacy flat format.
+func ParseScanFindings(data []byte) (*ScanFindings, error) {
+	// Try new format first (has "findings" wrapper)
+	var snap Snapshot
+	if err := json.Unmarshal(data, &snap); err == nil && snap.Version != "" {
+		return &snap.Findings, nil
+	}
+
+	// Fall back to legacy flat format
+	var findings ScanFindings
+	if err := json.Unmarshal(data, &findings); err != nil {
+		return nil, fmt.Errorf("failed to parse snapshot: %w", err)
+	}
+
+	return &findings, nil
+}

--- a/pkg/analysis/snapshot_test.go
+++ b/pkg/analysis/snapshot_test.go
@@ -1,0 +1,223 @@
+package analysis
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+func TestSnapshotRoundtrip(t *testing.T) {
+	findings := ScanFindings{
+		RBACFindings: []RBACFinding{
+			{CheckID: "RBAC001", Title: "Wildcard verbs", Severity: graph.SeverityHigh,
+				Affected: []AffectedResource{{Namespace: "default", Name: "admin"}}},
+		},
+		PodSecFindings: []PodSecurityFinding{
+			{CheckID: "PSS001", Title: "Privileged container", Severity: graph.SeverityCritical,
+				Affected: []AffectedWorkload{{Namespace: "kube-system", Name: "debug-pod"}}},
+		},
+		NetPolFindings: []NetworkPolicyFinding{
+			{CheckID: "NET001", Title: "Missing network policy", Severity: graph.SeverityMedium,
+				Affected: []AffectedNetworkResource{{Namespace: "prod", Name: "api-svc"}}},
+		},
+		CloudFindings: []CloudIAMFinding{
+			{Title: "Admin role", Provider: "aws", Category: CloudCategoryAdminAccess,
+				Severity: graph.SeverityCritical, RoleARN: "arn:aws:iam::123:role/admin"},
+		},
+	}
+
+	stats := &SnapshotGraphStats{
+		TotalNodes:    42,
+		TotalEdges:    67,
+		WorkloadCount: 10,
+		SACount:       8,
+		RoleCount:     15,
+	}
+
+	snap := NewSnapshot(findings, stats)
+
+	if snap.Version != SnapshotVersion {
+		t.Errorf("expected version %s, got %s", SnapshotVersion, snap.Version)
+	}
+	if snap.Timestamp == "" {
+		t.Error("expected non-empty timestamp")
+	}
+
+	// Write to temp file
+	dir := t.TempDir()
+	path := filepath.Join(dir, "snapshot.json")
+
+	if err := WriteSnapshot(snap, path); err != nil {
+		t.Fatalf("WriteSnapshot failed: %v", err)
+	}
+
+	// Read back
+	loaded, err := LoadScanFindings(path)
+	if err != nil {
+		t.Fatalf("LoadScanFindings failed: %v", err)
+	}
+
+	if len(loaded.RBACFindings) != 1 {
+		t.Errorf("expected 1 RBAC finding, got %d", len(loaded.RBACFindings))
+	}
+	if loaded.RBACFindings[0].CheckID != "RBAC001" {
+		t.Errorf("expected RBAC001, got %s", loaded.RBACFindings[0].CheckID)
+	}
+	if len(loaded.PodSecFindings) != 1 {
+		t.Errorf("expected 1 PodSec finding, got %d", len(loaded.PodSecFindings))
+	}
+	if len(loaded.NetPolFindings) != 1 {
+		t.Errorf("expected 1 NetPol finding, got %d", len(loaded.NetPolFindings))
+	}
+	if len(loaded.CloudFindings) != 1 {
+		t.Errorf("expected 1 Cloud finding, got %d", len(loaded.CloudFindings))
+	}
+	if loaded.CloudFindings[0].RoleARN != "arn:aws:iam::123:role/admin" {
+		t.Errorf("expected arn:aws:iam::123:role/admin, got %s", loaded.CloudFindings[0].RoleARN)
+	}
+}
+
+func TestParseScanFindings_LegacyFormat(t *testing.T) {
+	// Legacy format: flat JSON without version/findings wrapper
+	legacy := map[string]interface{}{
+		"timestamp": "2025-01-01T00:00:00Z",
+		"rbac_findings": []map[string]interface{}{
+			{
+				"check_id": "RBAC001",
+				"title":    "Test finding",
+				"severity": "high",
+			},
+		},
+		"pod_security_findings":  []interface{}{},
+		"network_policy_findings": []interface{}{},
+		"cloud_findings":         []interface{}{},
+	}
+
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	findings, err := ParseScanFindings(data)
+	if err != nil {
+		t.Fatalf("ParseScanFindings failed for legacy format: %v", err)
+	}
+
+	if len(findings.RBACFindings) != 1 {
+		t.Errorf("expected 1 RBAC finding from legacy format, got %d", len(findings.RBACFindings))
+	}
+}
+
+func TestParseScanFindings_NewFormat(t *testing.T) {
+	snap := &Snapshot{
+		Version:   "1.0",
+		Timestamp: "2025-01-01T00:00:00Z",
+		GraphStats: &SnapshotGraphStats{
+			TotalNodes: 10,
+		},
+		Findings: ScanFindings{
+			RBACFindings: []RBACFinding{
+				{CheckID: "RBAC002", Title: "New format finding", Severity: graph.SeverityMedium},
+			},
+		},
+	}
+
+	data, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	findings, err := ParseScanFindings(data)
+	if err != nil {
+		t.Fatalf("ParseScanFindings failed for new format: %v", err)
+	}
+
+	if len(findings.RBACFindings) != 1 {
+		t.Errorf("expected 1 RBAC finding from new format, got %d", len(findings.RBACFindings))
+	}
+	if findings.RBACFindings[0].CheckID != "RBAC002" {
+		t.Errorf("expected RBAC002, got %s", findings.RBACFindings[0].CheckID)
+	}
+}
+
+func TestLoadScanFindings_NotFound(t *testing.T) {
+	_, err := LoadScanFindings("/nonexistent/path/to/file.json")
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestWriteSnapshot_Stdout(t *testing.T) {
+	snap := NewSnapshot(ScanFindings{}, nil)
+
+	// Redirect stdout
+	old := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := WriteSnapshot(snap, "")
+	w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Errorf("WriteSnapshot to stdout failed: %v", err)
+	}
+}
+
+func TestSnapshotDiffRoundtrip(t *testing.T) {
+	// Create baseline
+	baseline := ScanFindings{
+		RBACFindings: []RBACFinding{
+			{CheckID: "RBAC001", Title: "Finding A", Severity: graph.SeverityHigh,
+				Affected: []AffectedResource{{Namespace: "ns1", Name: "r1"}}},
+		},
+	}
+
+	// Create current with one new finding
+	current := ScanFindings{
+		RBACFindings: []RBACFinding{
+			{CheckID: "RBAC001", Title: "Finding A", Severity: graph.SeverityHigh,
+				Affected: []AffectedResource{{Namespace: "ns1", Name: "r1"}}},
+			{CheckID: "RBAC002", Title: "Finding B", Severity: graph.SeverityCritical,
+				Affected: []AffectedResource{{Namespace: "ns2", Name: "r2"}}},
+		},
+	}
+
+	dir := t.TempDir()
+
+	// Write both snapshots
+	baseSnap := NewSnapshot(baseline, nil)
+	curSnap := NewSnapshot(current, nil)
+
+	basePath := filepath.Join(dir, "baseline.json")
+	curPath := filepath.Join(dir, "current.json")
+
+	if err := WriteSnapshot(baseSnap, basePath); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteSnapshot(curSnap, curPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load and diff
+	baseLoaded, err := LoadScanFindings(basePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	curLoaded, err := LoadScanFindings(curPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := ComputeDiff(baseLoaded, curLoaded)
+
+	if result.Summary.NewCount != 1 {
+		t.Errorf("expected 1 new finding, got %d", result.Summary.NewCount)
+	}
+	if result.Summary.Status != "degraded" {
+		t.Errorf("expected degraded, got %s", result.Summary.Status)
+	}
+}

--- a/pkg/watch/watcher.go
+++ b/pkg/watch/watcher.go
@@ -36,6 +36,9 @@ type Config struct {
 	MetricsAddr    string
 	WebhookURL     string
 	WebhookHeaders map[string]string
+	BaselineFile   string
+	AlertOnDrift   bool
+	DriftOnly      bool
 }
 
 type Watcher struct {
@@ -47,6 +50,7 @@ type Watcher struct {
 	webhook    *WebhookNotifier
 	mu         sync.Mutex
 	lastState  *WatchState
+	baseline   *analysis.ScanFindings
 	debouncer  *debouncer
 	opts       collector.Options
 }
@@ -140,6 +144,14 @@ func New(config Config) (*Watcher, error) {
 		w.webhook = NewWebhookNotifier(config.WebhookURL, config.WebhookHeaders)
 	}
 
+	if config.BaselineFile != "" {
+		baseline, err := analysis.LoadScanFindings(config.BaselineFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load baseline: %w", err)
+		}
+		w.baseline = baseline
+	}
+
 	w.debouncer = newDebouncer(config.DebouncePeriod, w.analyze)
 
 	return w, nil
@@ -158,6 +170,10 @@ func (w *Watcher) Run(ctx context.Context) error {
 	}
 	if w.config.WebhookURL != "" {
 		fmt.Fprintf(os.Stderr, "  Webhook: %s\n", w.config.WebhookURL)
+	}
+	if w.baseline != nil {
+		fmt.Fprintf(os.Stderr, "  Baseline: %s (alert-on-drift=%v, drift-only=%v)\n",
+			w.config.BaselineFile, w.config.AlertOnDrift, w.config.DriftOnly)
 	}
 
 	if err := w.setupInformers(); err != nil {
@@ -398,7 +414,49 @@ func (w *Watcher) analyze() {
 		}
 	}
 
+	// Baseline drift detection
+	if w.baseline != nil {
+		currentFindings := &analysis.ScanFindings{
+			RBACFindings:   newState.RBACFindings,
+			PodSecFindings: newState.PodSecFindings,
+			NetPolFindings: newState.NetPolFindings,
+		}
+		diff := analysis.ComputeDiff(w.baseline, currentFindings)
+
+		if diff.Summary.Status != "unchanged" {
+			if w.config.AlertOnDrift || w.config.DriftOnly {
+				fmt.Fprintf(os.Stderr, "DRIFT DETECTED: status=%s new=%d resolved=%d unchanged=%d\n",
+					diff.Summary.Status, diff.Summary.NewCount, diff.Summary.ResolvedCount, diff.UnchangedCount)
+				for _, f := range diff.NewFindings {
+					fmt.Fprintf(os.Stderr, "  + [%s] %s - %s", f.Severity, f.CheckID, f.Title)
+					if f.Namespace != "" {
+						fmt.Fprintf(os.Stderr, " (%s/%s)", f.Namespace, f.Resource)
+					}
+					fmt.Fprintln(os.Stderr)
+				}
+				for _, f := range diff.ResolvedFindings {
+					fmt.Fprintf(os.Stderr, "  - [%s] %s - %s", f.Severity, f.CheckID, f.Title)
+					if f.Namespace != "" {
+						fmt.Fprintf(os.Stderr, " (%s/%s)", f.Namespace, f.Resource)
+					}
+					fmt.Fprintln(os.Stderr)
+				}
+			}
+
+			if w.webhook != nil {
+				w.webhook.SendDrift(diff)
+			}
+		}
+	}
+
 	elapsed := time.Since(start)
+
+	if w.config.DriftOnly && w.baseline != nil {
+		// In drift-only mode, skip the normal analysis output unless there's drift
+		w.lastState = newState
+		return
+	}
+
 	fmt.Fprintf(os.Stderr, "[%s] Analysis complete in %v: %d findings (critical=%d, high=%d, medium=%d, low=%d)\n",
 		newState.Timestamp.Format("15:04:05"),
 		elapsed.Round(time.Millisecond),

--- a/pkg/watch/webhook.go
+++ b/pkg/watch/webhook.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/nelssec/identity-chain/pkg/analysis"
 )
 
 type WebhookNotifier struct {
@@ -91,6 +93,70 @@ func (w *WebhookNotifier) Send(findings []FindingChange) {
 	} else {
 		fmt.Fprintf(os.Stderr, "Webhook sent: %d new findings (critical=%d, high=%d)\n",
 			summary.NewFindings, summary.CriticalCount, summary.HighCount)
+	}
+}
+
+// DriftWebhookPayload is the webhook payload for drift detection events.
+type DriftWebhookPayload struct {
+	Timestamp time.Time              `json:"timestamp"`
+	Event     string                 `json:"event"`
+	Diff      *analysis.DiffResult   `json:"diff"`
+	Summary   DriftWebhookSummary    `json:"summary"`
+}
+
+// DriftWebhookSummary has high-level drift stats for the webhook.
+type DriftWebhookSummary struct {
+	Status        string `json:"status"`
+	NewCount      int    `json:"new_count"`
+	ResolvedCount int    `json:"resolved_count"`
+}
+
+// SendDrift sends a drift_detected webhook event.
+func (w *WebhookNotifier) SendDrift(diff *analysis.DiffResult) {
+	if diff == nil {
+		return
+	}
+
+	payload := DriftWebhookPayload{
+		Timestamp: time.Now(),
+		Event:     "drift_detected",
+		Diff:      diff,
+		Summary: DriftWebhookSummary{
+			Status:        diff.Summary.Status,
+			NewCount:      diff.Summary.NewCount,
+			ResolvedCount: diff.Summary.ResolvedCount,
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Failed to marshal drift webhook payload: %v\n", err)
+		return
+	}
+
+	req, err := http.NewRequest("POST", w.url, bytes.NewReader(body))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Failed to create drift webhook request: %v\n", err)
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range w.headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := w.client.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Failed to send drift webhook: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		fmt.Fprintf(os.Stderr, "WARNING: Drift webhook returned status %d\n", resp.StatusCode)
+	} else {
+		fmt.Fprintf(os.Stderr, "Drift webhook sent: status=%s new=%d resolved=%d\n",
+			diff.Summary.Status, diff.Summary.NewCount, diff.Summary.ResolvedCount)
 	}
 }
 


### PR DESCRIPTION
## Summary

Addresses issue #7 — wires up snapshot → diff → alert so operators can capture a known-good baseline and watch for identity posture drift.

## Changes

### New: Snapshot Save Subcommand
- `idc snapshot save --output baseline.json` writes a versioned, portable JSON baseline
- Includes `version`, `timestamp`, `graph_stats`, and all findings
- Backward compatible: `idc snapshot -f file.json` still works

### New: Watch Mode Drift Detection
- `idc watch --baseline baseline.json --alert-on-drift` — diffs against baseline on each analysis cycle
- `idc watch --baseline baseline.json --drift-only` — only shows changes from baseline (suppresses normal output)
- Drift events printed to stderr with `+` (new) and `-` (resolved) prefixes

### New: Drift Webhook Events
- `drift_detected` webhook event with full `DiffResult` payload (new findings, resolved, summary)
- `SendDrift()` method on `WebhookNotifier`

### New: Offline Diff Mode
- `idc diff --from baseline.json --to current.json` compares two snapshot files without cluster access
- Supports both new versioned format and legacy flat JSON

### New: Snapshot Library (`pkg/analysis/snapshot.go`)
- `Snapshot` type with `NewSnapshot()`, `WriteSnapshot()`, `LoadScanFindings()`
- `ParseScanFindings()` handles both formats transparently

### Tests
- 8 diff tests covering nil baseline, unchanged, new/resolved/mixed findings, cross-type, severity
- 6 snapshot tests covering roundtrip, legacy/new format parsing, error cases, diff integration

## Acceptance Criteria
- [x] `idc snapshot save` writes a portable JSON baseline
- [x] `idc watch --baseline baseline.json` diffs on each cycle
- [x] New/changed findings trigger webhook payload with diff context
- [x] `idc diff --from baseline.json --to current.json` works as a one-shot CLI command
- [x] Tests for snapshot serialization and diff logic