### PR TITLE
feat: remediate --dry-run outputs actionable K8s YAML patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,19 @@ idc remediate -A -f fixes.yaml                    # Generate all fix manifests
 idc remediate -A --severity critical              # Only critical fixes
 idc remediate -A --type rbac -f rbac-fixes.yaml   # Only RBAC fixes
 idc remediate -A --manifests-only                 # Just YAML, no summary
+idc remediate -A --dry-run -o yaml > fixes.yaml   # Actionable YAML for kubectl apply
 ```
+
+**Dry-run workflow** — generate, validate, and apply patches:
+
+```bash
+idc remediate -A --dry-run -o yaml > fixes.yaml   # Generate actionable patches
+kubectl apply -f fixes.yaml --dry-run=client       # Validate against cluster
+kubectl apply -f fixes.yaml                        # Apply fixes
+```
+
+The `--dry-run` flag outputs only actionable K8s manifests (skipping review-only comments)
+with `# idc: <finding-id> <severity>` traceability comments before each resource.
 
 Generates ready-to-apply YAML for:
 - RBAC issues (cluster-admin, secrets access, wildcards)

--- a/cmd/idc/main.go
+++ b/cmd/idc/main.go
@@ -1899,6 +1899,8 @@ func remediateCmd() *cobra.Command {
 	var minSeverity string
 	var remType string
 	var manifestsOnly bool
+	var dryRun bool
+	var outputFormat string
 
 	cmd := &cobra.Command{
 		Use:   "remediate",
@@ -1910,7 +1912,14 @@ Examples:
   idc remediate -A -f fixes.yaml
   idc remediate -A --severity critical
   idc remediate -A --type rbac -f rbac-fixes.yaml
-  idc remediate -A --manifests-only`,
+  idc remediate -A --manifests-only
+  idc remediate -A --dry-run -o yaml > fixes.yaml
+  idc remediate -A --dry-run -o yaml | kubectl apply --dry-run=client -f -
+
+Dry-run workflow:
+  idc remediate -A --dry-run -o yaml > fixes.yaml   # generate patches
+  kubectl apply -f fixes.yaml --dry-run=client       # validate
+  kubectl apply -f fixes.yaml                        # apply`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 			defer cancel()
@@ -1985,6 +1994,21 @@ Examples:
 				out = os.Stdout
 			}
 
+			if dryRun || outputFormat == "yaml" {
+				yaml := result.GenerateDryRunYAML()
+				if yaml == "" {
+					fmt.Fprintln(os.Stderr, "No actionable manifests to output.")
+					return nil
+				}
+				fmt.Fprint(out, yaml)
+				if outputFile != "" {
+					fmt.Fprintf(os.Stderr, "Dry-run manifests saved to: %s\n", outputFile)
+					fmt.Fprintf(os.Stderr, "\nTo validate: kubectl apply -f %s --dry-run=client\n", outputFile)
+					fmt.Fprintf(os.Stderr, "To apply:    kubectl apply -f %s\n", outputFile)
+				}
+				return nil
+			}
+
 			if manifestsOnly {
 				fmt.Fprint(out, result.CombinedManifests)
 				if outputFile != "" {
@@ -2054,6 +2078,8 @@ Examples:
 	cmd.Flags().StringVar(&minSeverity, "severity", "", "Minimum severity to include (critical, high, medium, low)")
 	cmd.Flags().StringVar(&remType, "type", "", "Filter by type (rbac, pod-security, network-policy)")
 	cmd.Flags().BoolVar(&manifestsOnly, "manifests-only", false, "Output only the YAML manifests")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Output actionable YAML patches for kubectl apply (skips review-only manifests)")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format: yaml (same as --dry-run)")
 
 	return cmd
 }

--- a/pkg/remediation/manifest_test.go
+++ b/pkg/remediation/manifest_test.go
@@ -1,0 +1,224 @@
+package remediation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nelssec/identity-chain/pkg/analysis"
+	"github.com/nelssec/identity-chain/pkg/graph"
+)
+
+func makeRBACFinding(checkID string, severity graph.Severity, ns, name string) analysis.RBACFinding {
+	return analysis.RBACFinding{
+		CheckID:     checkID,
+		Category:    analysis.CategoryOverPermissive,
+		Severity:    severity,
+		Title:       checkID + " finding",
+		Description: "Test finding for " + checkID,
+		Affected: []analysis.AffectedResource{
+			{Kind: "ClusterRoleBinding", Namespace: ns, Name: name, Details: "test"},
+		},
+		Remediation: "Fix it",
+	}
+}
+
+func makePodSecFinding(checkID string, severity graph.Severity, ns, name string) analysis.PodSecurityFinding {
+	return analysis.PodSecurityFinding{
+		CheckID:     checkID,
+		Category:    "container_security",
+		Severity:    severity,
+		Title:       checkID + " finding",
+		Description: "Test finding for " + checkID,
+		Affected: []analysis.AffectedWorkload{
+			{Kind: "Deployment", Namespace: ns, Name: name, Container: "app", Details: "test"},
+		},
+		Remediation: "Fix it",
+	}
+}
+
+func makeNetPolFinding(checkID string, severity graph.Severity, ns, name string) analysis.NetworkPolicyFinding {
+	return analysis.NetworkPolicyFinding{
+		CheckID:     checkID,
+		Category:    "network_exposure",
+		Severity:    severity,
+		Title:       checkID + " finding",
+		Description: "Test finding for " + checkID,
+		Affected: []analysis.AffectedNetworkResource{
+			{Kind: "Namespace", Namespace: ns, Name: name, Details: "test"},
+		},
+		Remediation: "Fix it",
+	}
+}
+
+func TestGenerateDryRunYAML_RBAC(t *testing.T) {
+	findings := []analysis.RBACFinding{
+		makeRBACFinding("RBAC004", graph.SeverityCritical, "default", "admin-binding"),
+	}
+
+	result := GenerateAllRemediations(findings, nil, nil)
+	yaml := result.GenerateDryRunYAML()
+
+	if yaml == "" {
+		t.Fatal("expected non-empty dry-run YAML for RBAC findings")
+	}
+
+	if !strings.Contains(yaml, "# idc:") {
+		t.Error("dry-run YAML should contain # idc: traceability comment")
+	}
+
+	if !strings.Contains(yaml, "critical") {
+		t.Error("dry-run YAML should contain severity")
+	}
+
+	if !strings.Contains(yaml, "apiVersion:") {
+		t.Error("dry-run YAML should contain actual K8s manifests with apiVersion")
+	}
+}
+
+func TestGenerateDryRunYAML_NetworkPolicy(t *testing.T) {
+	findings := []analysis.NetworkPolicyFinding{
+		makeNetPolFinding("NET001", graph.SeverityHigh, "production", "production"),
+	}
+
+	result := GenerateAllRemediations(nil, nil, findings)
+	yaml := result.GenerateDryRunYAML()
+
+	if yaml == "" {
+		t.Fatal("expected non-empty dry-run YAML for network policy findings")
+	}
+
+	if !strings.Contains(yaml, "NetworkPolicy") {
+		t.Error("dry-run YAML should contain NetworkPolicy resources")
+	}
+
+	if !strings.Contains(yaml, "# idc:") {
+		t.Error("dry-run YAML should contain # idc: traceability comment")
+	}
+}
+
+func TestGenerateDryRunYAML_PodSecurity(t *testing.T) {
+	findings := []analysis.PodSecurityFinding{
+		makePodSecFinding("PSS001", graph.SeverityCritical, "default", "my-deploy"),
+	}
+
+	result := GenerateAllRemediations(nil, findings, nil)
+	yaml := result.GenerateDryRunYAML()
+
+	if yaml == "" {
+		t.Fatal("expected non-empty dry-run YAML for pod security findings")
+	}
+
+	if !strings.Contains(yaml, "# idc:") {
+		t.Error("dry-run YAML should contain # idc: traceability comment")
+	}
+}
+
+func TestGenerateDryRunYAML_FindingIDInComment(t *testing.T) {
+	findings := []analysis.RBACFinding{
+		makeRBACFinding("RBAC004", graph.SeverityCritical, "default", "admin-binding"),
+	}
+
+	result := GenerateAllRemediations(findings, nil, nil)
+	yaml := result.GenerateDryRunYAML()
+
+	// FindingID format: CheckID-Namespace-Name
+	if !strings.Contains(yaml, "# idc: RBAC004-default-admin-binding critical") {
+		t.Errorf("expected '# idc: RBAC004-default-admin-binding critical' in YAML, got:\n%s", yaml)
+	}
+}
+
+func TestGenerateDryRunYAML_SkipsReviewOnlyManifests(t *testing.T) {
+	result := &RemediationResult{
+		TotalFindings:   2,
+		RemediableCount: 2,
+		Remediations: []Remediation{
+			{
+				FindingID: "TEST001-default-test",
+				CheckID:   "TEST001",
+				Severity:  "high",
+				Manifests: []Manifest{
+					{
+						Action:      "review",
+						Description: "Review this manually",
+						YAML:        "# This is a review-only comment, not a K8s resource",
+					},
+				},
+			},
+			{
+				FindingID: "TEST002-default-test",
+				CheckID:   "TEST002",
+				Severity:  "critical",
+				Manifests: []Manifest{
+					{
+						Action:      "create",
+						Description: "Create a role",
+						YAML: `apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: test-role
+  namespace: default`,
+					},
+				},
+			},
+		},
+	}
+
+	yaml := result.GenerateDryRunYAML()
+
+	if strings.Contains(yaml, "review-only") {
+		t.Error("dry-run YAML should not contain review-only manifests")
+	}
+
+	if !strings.Contains(yaml, "TEST002") {
+		t.Error("dry-run YAML should contain actionable manifests")
+	}
+
+	if strings.Contains(yaml, "TEST001") {
+		t.Error("dry-run YAML should not contain review-only finding ID")
+	}
+}
+
+func TestGenerateCombinedManifests_DeduplicatesManifests(t *testing.T) {
+	sharedYAML := `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: production`
+
+	result := &RemediationResult{
+		TotalFindings:   2,
+		RemediableCount: 2,
+		Remediations: []Remediation{
+			{
+				FindingID: "NET001-production",
+				CheckID:   "NET001",
+				Severity:  "high",
+				Manifests: []Manifest{
+					{Action: "create", Description: "Create default deny", YAML: sharedYAML},
+				},
+			},
+			{
+				FindingID: "NET003-production",
+				CheckID:   "NET003",
+				Severity:  "medium",
+				Manifests: []Manifest{
+					{Action: "create", Description: "Create default deny", YAML: sharedYAML},
+				},
+			},
+		},
+	}
+
+	combined := result.GenerateCombinedManifests()
+
+	count := strings.Count(combined, "default-deny")
+	if count != 1 {
+		t.Errorf("expected manifest to appear once (deduplication), but appeared %d times", count)
+	}
+
+	// Also verify dry-run deduplication
+	dryRun := result.GenerateDryRunYAML()
+	count = strings.Count(dryRun, "default-deny")
+	if count != 1 {
+		t.Errorf("expected dry-run manifest to appear once (deduplication), but appeared %d times", count)
+	}
+}

--- a/pkg/remediation/remediation.go
+++ b/pkg/remediation/remediation.go
@@ -2,6 +2,7 @@ package remediation
 
 import (
 	"fmt"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -72,13 +73,45 @@ func (rr *RemediationResult) GenerateCombinedManifests() string {
 			if combined != "" {
 				combined += "---\n"
 			}
-			combined += fmt.Sprintf("# %s: %s\n", r.CheckID, m.Description)
+			combined += fmt.Sprintf("# idc: %s %s\n", r.FindingID, r.Severity)
+			combined += fmt.Sprintf("# action: %s | %s\n", m.Action, m.Description)
 			combined += m.YAML + "\n"
 		}
 	}
 
 	rr.CombinedManifests = combined
 	return combined
+}
+
+// GenerateDryRunYAML generates clean YAML output suitable for kubectl apply.
+// It skips review-only manifests (where YAML starts with #) and includes
+// idc traceability comments before each manifest.
+func (rr *RemediationResult) GenerateDryRunYAML() string {
+	var parts []string
+	seen := make(map[string]bool)
+
+	for _, r := range rr.Remediations {
+		for _, m := range r.Manifests {
+			trimmed := strings.TrimSpace(m.YAML)
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+
+			key := fmt.Sprintf("%s-%s", m.Action, m.YAML)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+
+			block := fmt.Sprintf("# idc: %s %s\n%s", r.FindingID, r.Severity, m.YAML)
+			parts = append(parts, block)
+		}
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "\n---\n") + "\n"
 }
 
 func toYAMLString(obj interface{}) string {


### PR DESCRIPTION
## Summary

Addresses issue #8 — bridges the gap between security findings and actual fixes by adding `--dry-run` and `--output yaml` flags to `idc remediate`.

## Changes

### `pkg/remediation/remediation.go`
- Added `GenerateDryRunYAML()` method that produces clean K8s YAML with `# idc: <finding-id> <severity>` traceability comments, skipping review-only manifests (YAML starting with `#`)
- Updated `GenerateCombinedManifests()` to use the `# idc: <id> <severity>` format for consistency

### `cmd/idc/main.go`
- Added `--dry-run` flag to `remediateCmd()`
- Added `--output` / `-o` flag (set to `yaml` for same effect)
- Updated help text with dry-run workflow

### `pkg/remediation/manifest_test.go` (new)
Six tests covering:
- RBAC, NetworkPolicy, PodSecurity manifest generation
- `# idc: <finding-id> <severity>` comment format
- Review-only manifest skipping
- Deduplication

### `README.md`
Added dry-run workflow example.

## Usage

```bash
# Generate and apply patches
idc remediate -A --dry-run -o yaml > fixes.yaml
kubectl apply -f fixes.yaml --dry-run=client
kubectl apply -f fixes.yaml

# Pipe directly
idc remediate -A --dry-run -o yaml | kubectl apply --dry-run=client -f -
```

## Acceptance Criteria

- [x] YAML patches generated for RBAC findings
- [x] YAML patches generated for NetworkPolicy findings  
- [x] YAML patches generated for PodSecurity findings
- [x] Output is valid YAML that `kubectl apply --dry-run=client` accepts
- [x] Tests for manifest generation (6 tests, all passing)
- [x] Docs/help text updated